### PR TITLE
DX-8267: Expose the ability to set last set value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ MANIFEST
 
 cpp/.idea/
 python/.eggs/
+.idea/

--- a/java/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/java/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -717,6 +717,14 @@ public final class ${className} extends BaseDataValueVector implements FixedWidt
      data.writerIndex(valueCount * ${type.width});
    }
  }
+
+ /**
+  * Sets the last number of values stored in this vector to the given value count
+  * @param value the last count to set
+  */
+  public void setLastSet(int value) {
+      this.getMutator().setLastSetValueCount(value);
+  }
 }
 
   </#if> <#-- type.major -->

--- a/java/vector/src/main/codegen/templates/FixedValueVectors.java
+++ b/java/vector/src/main/codegen/templates/FixedValueVectors.java
@@ -718,10 +718,7 @@ public final class ${className} extends BaseDataValueVector implements FixedWidt
    }
  }
 
- /**
-  * Sets the last number of values stored in this vector to the given value count
-  * @param value the last count to set
-  */
+  @Override
   public void setLastSet(int value) {
       this.getMutator().setLastSetValueCount(value);
   }

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -707,10 +707,7 @@ public final class ${className} extends BaseDataValueVector implements <#if type
     }
   }
 
-  /**
-   * Sets the last number of values stored in this vector to the given value count
-   * @param value the last count to set
-   */
+  @Override
   public void setLastSet(int value) {
     this.getMutator().setLastSetValueCount(value);
   }

--- a/java/vector/src/main/codegen/templates/NullableValueVectors.java
+++ b/java/vector/src/main/codegen/templates/NullableValueVectors.java
@@ -699,6 +699,20 @@ public final class ${className} extends BaseDataValueVector implements <#if type
       setCount = 0;
       <#if type.major = "VarLen">lastSet = -1;</#if>
     }
+
+    @Override
+    public void setLastSetValueCount(int value) {
+      values.getMutator().setLastSetValueCount(value);
+      bits.getMutator().setLastSetValueCount(value);
+    }
+  }
+
+  /**
+   * Sets the last number of values stored in this vector to the given value count
+   * @param value the last count to set
+   */
+  public void setLastSet(int value) {
+    this.getMutator().setLastSetValueCount(value);
   }
 }
 </#list>

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
@@ -19,7 +19,6 @@ package org.apache.arrow.vector;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.lang.reflect.Field;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
@@ -27,8 +26,6 @@ import org.apache.arrow.vector.schema.ArrowFieldNode;
 import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
-
-import com.google.common.base.Throwables;
 
 
 public abstract class BaseDataValueVector extends BaseValueVector implements BufferBacked {
@@ -144,13 +141,9 @@ public abstract class BaseDataValueVector extends BaseValueVector implements Buf
    */
   public void reset() {}
 
-  public void setLastSet(int value) {
-    try {
-      Field f = this.getMutator().getClass().getDeclaredField("lastSet");
-      f.setAccessible(true);
-      f.set(this.getMutator(), value);
-    } catch (Exception ex) {
-      throw Throwables.propagate(ex);
-    }
-  }
+  /**
+   * Sets the last number of values stored in this vector to the given value count
+   * @param value the last count to set
+   */
+  public abstract void setLastSet(int value);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseDataValueVector.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.reflect.Field;
 
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.schema.ArrowFieldNode;
@@ -26,6 +27,8 @@ import org.apache.arrow.vector.schema.ArrowFieldNode;
 import io.netty.buffer.ArrowBuf;
 import org.apache.arrow.vector.util.CallBack;
 import org.apache.arrow.vector.util.TransferPair;
+
+import com.google.common.base.Throwables;
 
 
 public abstract class BaseDataValueVector extends BaseValueVector implements BufferBacked {
@@ -140,4 +143,14 @@ public abstract class BaseDataValueVector extends BaseValueVector implements Buf
    * the value vector. The purpose is to move the value vector to a "mutate" state
    */
   public void reset() {}
+
+  public void setLastSet(int value) {
+    try {
+      Field f = this.getMutator().getClass().getDeclaredField("lastSet");
+      f.setAccessible(true);
+      f.set(this.getMutator(), value);
+    } catch (Exception ex) {
+      throw Throwables.propagate(ex);
+    }
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -87,7 +87,7 @@ public abstract class BaseValueVector implements ValueVector {
   }
 
   public abstract static class BaseMutator implements ValueVector.Mutator {
-    public int lastSetValueCount;
+    private int lastSetValueCount;
     protected BaseMutator() { }
 
     @Override
@@ -100,6 +100,8 @@ public abstract class BaseValueVector implements ValueVector {
     public void setLastSetValueCount(int value) {
       lastSetValueCount = value;
     }
+
+    public int getLastSetValueCount() { return lastSetValueCount; }
   }
 
   @Override
@@ -121,11 +123,5 @@ public abstract class BaseValueVector implements ValueVector {
   public BufferAllocator getAllocator() {
     return allocator;
   }
-
-  /**
-   * Sets the last number of values stored in this vector to the given value count
-   * @param value the last count to set
-   */
-  public abstract void setLastSet(int value);
 }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -87,6 +87,7 @@ public abstract class BaseValueVector implements ValueVector {
   }
 
   public abstract static class BaseMutator implements ValueVector.Mutator {
+    public int lastSetValueCount;
     protected BaseMutator() { }
 
     @Override
@@ -95,6 +96,10 @@ public abstract class BaseValueVector implements ValueVector {
     //TODO: consider making mutator stateless(if possible) on another issue.
     @Override
     public void reset() {}
+
+    public void setLastSetValueCount(int value) {
+      lastSetValueCount = value;
+    }
   }
 
   @Override

--- a/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/BaseValueVector.java
@@ -116,5 +116,11 @@ public abstract class BaseValueVector implements ValueVector {
   public BufferAllocator getAllocator() {
     return allocator;
   }
+
+  /**
+   * Sets the last number of values stored in this vector to the given value count
+   * @param value the last count to set
+   */
+  public abstract void setLastSet(int value);
 }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -402,14 +402,4 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
       }
     }
   }
-
-  public void setLastSet(int value) {
-    try {
-      java.lang.reflect.Field f = this.getMutator().getClass().getDeclaredField("lastSet");
-      f.setAccessible(true);
-      f.set(this.getMutator(), value);
-    } catch (Exception ex) {
-      throw Throwables.propagate(ex);
-    }
-  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/FixedSizeListVector.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
+import com.google.common.base.Throwables;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ObjectArrays;
@@ -399,6 +400,16 @@ public class FixedSizeListVector extends BaseValueVector implements FieldVector,
       for (int i = 0; i < listSize; i++) {
         pairs[1].copyValueSafe(fromOffset + i, toOffset + i);
       }
+    }
+  }
+
+  public void setLastSet(int value) {
+    try {
+      java.lang.reflect.Field f = this.getMutator().getClass().getDeclaredField("lastSet");
+      f.setAccessible(true);
+      f.set(this.getMutator(), value);
+    } catch (Exception ex) {
+      throw Throwables.propagate(ex);
     }
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -411,14 +411,4 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
       bits.getMutator().setValueCount(valueCount);
     }
   }
-
-  public void setLastSet(int value) {
-    try {
-      java.lang.reflect.Field f = this.getMutator().getClass().getDeclaredField("lastSet");
-      f.setAccessible(true);
-      f.set(this.getMutator(), value);
-    } catch (Exception ex) {
-      throw Throwables.propagate(ex);
-    }
-  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ObjectArrays;
 
@@ -411,4 +412,13 @@ public class ListVector extends BaseRepeatedValueVector implements FieldVector, 
     }
   }
 
+  public void setLastSet(int value) {
+    try {
+      java.lang.reflect.Field f = this.getMutator().getClass().getDeclaredField("lastSet");
+      f.setAccessible(true);
+      f.set(this.getMutator(), value);
+    } catch (Exception ex) {
+      throw Throwables.propagate(ex);
+    }
+  }
 }


### PR DESCRIPTION
The changes here expose the ability in Dremio/Arrow to set the last set value in Vectors.

Currently, we have LastSetter.java and Vectors.java in Dremio/Dremio with static methods to do this on particular types of Vectors (NullableVarBinary, ListVector and NullableVarchar).

An abstract method has been declared in BaseValueVector and over-ridden in all the non-abstract sub-classes -- BaseDataValueVector, ListVector, FixedSizeListVector.

Since all the Nullable<*>Vector and <*>Vector extend BaseDataValueVector, the setLastSet(int value) is now generically available to all these vectors types.

Once this change goes in, a complimentary change-set will be pushed to Dremio/Dremio to:

(1) Remove LastSetter.java and accordingly update all the usages of its methods to use the new setLastSet() API on the required vectors.

(2) Do a similar cleanup in Vectors.java and subsequently update the callers of its methods to use setLastSet() API.

