### PR TITLE
DX-61688: AES_DECRYPT function reliably segfaults the JVM

### DIFF
--- a/cpp/src/gandiva/encrypt_utils_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_test.cc
@@ -151,5 +151,4 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_7), decrypted_7_len));
-
 }

--- a/cpp/src/gandiva/encrypt_utils_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_test.cc
@@ -151,4 +151,15 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_7), decrypted_7_len));
+
+
+    key = "abcdefghijklmnop";
+    auto* cipher_8 = "4A5jOAh9FNGwoMeuJukfllrLdHEZxA2DyuSQAWz77dfn";
+
+    auto cipher_8_len =
+        static_cast<int32_t>(strlen(reinterpret_cast<const char*>(cipher_8)));
+    unsigned char decrypted_8[64];
+
+   EXPECT_THROW(gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_8), cipher_8_len, key, decrypted_8), std::runtime_error);
+
 }

--- a/cpp/src/gandiva/encrypt_utils_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_test.cc
@@ -152,14 +152,4 @@ TEST(TestShaEncryptUtils, TestAesEncryptDecrypt) {
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_7), decrypted_7_len));
 
-
-    key = "abcdefghijklmnop";
-    auto* cipher_8 = "4A5jOAh9FNGwoMeuJukfllrLdHEZxA2DyuSQAWz77dfn";
-
-    auto cipher_8_len =
-        static_cast<int32_t>(strlen(reinterpret_cast<const char*>(cipher_8)));
-    unsigned char decrypted_8[64];
-
-   EXPECT_THROW(gandiva::aes_decrypt(reinterpret_cast<const char*>(cipher_8), cipher_8_len, key, decrypted_8), std::runtime_error);
-
 }

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -332,8 +332,8 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     *out_len = gandiva::aes_encrypt(data, data_len, key_data,
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
-    gdv_fn_context_set_error_msg(context, e.what());
-    return nullptr;
+    std::string err_msg = "Following error occurred while encrypting ciphertext - " + std::string(e.what());
+    gdv_fn_context_set_error_msg(context, err_msg.data());
   }
 
   return ret;
@@ -363,7 +363,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     *out_len = gandiva::aes_decrypt(data, data_len, key_data,
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
-    std::string err_msg = "Error occurred while decrypting ciphertext.";
+    std::string err_msg = "Following error occurred while decrypting ciphertext - " + std::string(e.what());
     gdv_fn_context_set_error_msg(context, err_msg.data());
   }
 

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -364,7 +364,6 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
-    return nullptr;
   }
 
   return ret;

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -363,7 +363,8 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     *out_len = gandiva::aes_decrypt(data, data_len, key_data,
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
-    gdv_fn_context_set_error_msg(context, e.what());
+    std::string err_msg = "Error occurred while decrypting ciphertext.";
+    gdv_fn_context_set_error_msg(context, err_msg.data());
   }
 
   return ret;


### PR DESCRIPTION
When aes_decrypt function throws a runtime error, a null pointer was returned which caused the segmentation fault.

Fix - Removed the error-causing null pointer return, replaced with a meaningful error return.