### PR TITLE
DX-61688 fixed out_len value for nullptr

### DIFF
--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -325,6 +325,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -333,6 +334,7 @@ const char* gdv_fn_aes_encrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -356,6 +358,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
     std::string err_msg =
         "Could not allocate memory for returning aes encrypt cypher text";
     gdv_fn_context_set_error_msg(context, err_msg.data());
+     *out_len = 0;
     return nullptr;
   }
 
@@ -364,6 +367,7 @@ const char* gdv_fn_aes_decrypt(int64_t context, const char* data, int32_t data_l
                                     reinterpret_cast<unsigned char*>(ret));
   } catch (const std::runtime_error& e) {
     gdv_fn_context_set_error_msg(context, e.what());
+     *out_len = 0;
     return nullptr;
   }
 


### PR DESCRIPTION
In case when when function return **nullptr**, ***out_len** value was not updated to 0;
Some explanation:
https://stackoverflow.com/questions/19390136/what-can-cause-a-java-native-function-in-c-to-segfault-upon-entry;
https://docs.oracle.com/en/java/javase/11/vm/error-reporting.html#GUID-2A43EBDE-5EF0-4E6D-AEB6-D6F4B08D8B0C