### PR TITLE
DX-66740: Added creating MapWriter in ComplexWriter.

### DIFF
--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -106,6 +106,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void copyReader(FieldReader reader);
     StructWriter rootAsStruct();
     ListWriter rootAsList();
+    MapWriter rootAsMap(boolean keysSorted);
 
     void setPosition(int index);
     void setValueCount(int count);

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ComplexWriterImpl.java
@@ -19,6 +19,7 @@ package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.complex.ListVector;
+import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.NonNullableStructVector;
 import org.apache.arrow.vector.complex.StateTool;
 import org.apache.arrow.vector.complex.StructVector;
@@ -32,6 +33,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
 
   private NullableStructWriter structRoot;
   private UnionListWriter listRoot;
+  private UnionMapWriter mapRoot;
   private final NonNullableStructVector container;
 
   Mode mode = Mode.INIT;
@@ -39,7 +41,7 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
   private final boolean unionEnabled;
   private final NullableStructWriterFactory nullableStructWriterFactory;
 
-  private enum Mode { INIT, STRUCT, LIST }
+  private enum Mode { INIT, STRUCT, LIST, MAP }
 
   /**
    * Constructs a new instance.
@@ -107,6 +109,9 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
       case LIST:
         listRoot.clear();
         break;
+      case MAP:
+        mapRoot.clear();
+        break;
       default:
         break;
     }
@@ -120,6 +125,9 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
         break;
       case LIST:
         listRoot.setValueCount(count);
+        break;
+      case MAP:
+        mapRoot.setValueCount(count);
         break;
       default:
         break;
@@ -135,6 +143,9 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
         break;
       case LIST:
         listRoot.setPosition(index);
+        break;
+      case MAP:
+        mapRoot.setPosition(index);
         break;
       default:
         break;
@@ -221,6 +232,32 @@ public class ComplexWriterImpl extends AbstractFieldWriter implements ComplexWri
     }
 
     return listRoot;
+  }
+
+  @Override
+  public MapWriter rootAsMap(boolean keysSorted) {
+    switch (mode) {
+
+      case INIT:
+        int vectorCount = container.size();
+        // TODO allow dictionaries in complex types
+        MapVector mapVector = container.addOrGetMap(name, keysSorted);
+        if (container.size() > vectorCount) {
+          mapVector.allocateNew();
+        }
+        mapRoot = new UnionMapWriter(mapVector);
+        mapRoot.setPosition(idx());
+        mode = Mode.MAP;
+        break;
+
+      case MAP:
+        break;
+
+      default:
+        check(Mode.INIT, Mode.STRUCT);
+    }
+
+    return mapRoot;
   }
 
 

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/writer/TestComplexWriter.java
@@ -51,7 +51,6 @@ import org.apache.arrow.vector.complex.impl.UnionMapReader;
 import org.apache.arrow.vector.complex.impl.UnionMapWriter;
 import org.apache.arrow.vector.complex.impl.UnionReader;
 import org.apache.arrow.vector.complex.impl.UnionWriter;
-import org.apache.arrow.vector.complex.reader.BaseReader;
 import org.apache.arrow.vector.complex.reader.BaseReader.StructReader;
 import org.apache.arrow.vector.complex.reader.BigIntReader;
 import org.apache.arrow.vector.complex.reader.FieldReader;
@@ -1403,6 +1402,7 @@ public class TestComplexWriter {
       Assert.assertEquals(0, size);
     }
   }
+
   @Test
   public void testMap() {
     try (MapVector mapVector = MapVector.empty("map", allocator, false)) {
@@ -1414,7 +1414,7 @@ public class TestComplexWriter {
           mapWriter.startEntry();
           if (j % 2 == 0) {
             mapWriter.key().integer().writeInt(j);
-            mapWriter.value().integer().writeInt(j+1);
+            mapWriter.value().integer().writeInt(j + 1);
           } else {
             IntHolder keyHolder = new IntHolder();
             keyHolder.value = j;
@@ -1434,7 +1434,7 @@ public class TestComplexWriter {
         for (int j = 0; j < i % 7; j++) {
           mapReader.next();
           assertEquals(j, mapReader.key().readInteger().intValue());
-          assertEquals(j+1, mapReader.value().readInteger().intValue());
+          assertEquals(j + 1, mapReader.value().readInteger().intValue());
         }
       }
     }
@@ -1458,32 +1458,32 @@ public class TestComplexWriter {
     }
   }
 
-    @Test
-    public void testMapWithListKey() {
-      try (MapVector mapVector = MapVector.empty("map", allocator, false)) {
-        mapVector.allocateNew();
-        UnionMapWriter mapWriter = new UnionMapWriter(mapVector);
-        mapWriter.startMap();
-        mapWriter.startEntry();
-        mapWriter.key().list().startList();
-        for (int i = 0; i < 3; i++) {
-          mapWriter.key().list().integer().writeInt(i);
-        }
-        mapWriter.key().list().endList();
-        mapWriter.value().integer().writeInt(1);
-        mapWriter.endEntry();
-        mapWriter.endMap();
-        mapWriter.setValueCount(1);
-        UnionMapReader mapReader = new UnionMapReader(mapVector);
-        mapReader.key().next();
-        assertEquals(0, mapReader.key().reader().readInteger().intValue());
-        mapReader.key().next();
-        assertEquals(1, mapReader.key().reader().readInteger().intValue());
-        mapReader.key().next();
-        assertEquals(2, mapReader.key().reader().readInteger().intValue());
-        assertEquals(1, mapReader.value().readInteger().intValue());
+  @Test
+  public void testMapWithListKey() {
+    try (MapVector mapVector = MapVector.empty("map", allocator, false)) {
+      mapVector.allocateNew();
+      UnionMapWriter mapWriter = new UnionMapWriter(mapVector);
+      mapWriter.startMap();
+      mapWriter.startEntry();
+      mapWriter.key().list().startList();
+      for (int i = 0; i < 3; i++) {
+        mapWriter.key().list().integer().writeInt(i);
       }
+      mapWriter.key().list().endList();
+      mapWriter.value().integer().writeInt(1);
+      mapWriter.endEntry();
+      mapWriter.endMap();
+      mapWriter.setValueCount(1);
+      UnionMapReader mapReader = new UnionMapReader(mapVector);
+      mapReader.key().next();
+      assertEquals(0, mapReader.key().reader().readInteger().intValue());
+      mapReader.key().next();
+      assertEquals(1, mapReader.key().reader().readInteger().intValue());
+      mapReader.key().next();
+      assertEquals(2, mapReader.key().reader().readInteger().intValue());
+      assertEquals(1, mapReader.value().readInteger().intValue());
     }
+  }
 
   @Test
   public void testMapWithStruckKey() {


### PR DESCRIPTION
Added new method rootAsMap() to ComplexWriter and implement it in ComplexWriterImpl for supporting @Output map type. **Need this to unlock ARRAY_FREQUENCY function.**

Previously in dremio side:

When i trying to return map like @Output ComplexWrite
with this code:
```
org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter mapWriter = out.rootAsList().map(false);

mapWriter.startMap();
for (java.util.Map.Entry<java.lang.Integer, java.lang.Integer> element : map.entrySet()) {
    mapWriter.startEntry();
    mapWriter.key().integer().writeInt((Integer) element.getKey());
    mapWriter.value().integer().writeInt((Integer) element.getValue());
    mapWriter.endEntry();
}
mapWriter.endMap();
```
It use UnionMapWriter and generate schema like:
`EXPR$0: Map(false)<$data$: Union(Sparse, [1, 39])<struct: Struct<key: Int(32, true) not null, value: Int(32, true) not null> not null, map: Map(false)<entries: Struct<key: Int(32, true) not null, value: Int(32, true)> not null>>`>
But in OutputDerivation impl class where i should create output Complete type
```
List<Field> children = Arrays.asList( CompleteType.INT.toField("key", false), CompleteType.INT.toField("value", false));
return new CompleteType(CompleteType.MAP.getType(), CompleteType.struct(children).toField(MapVector.DATA_VECTOR_NAME, false));
```
(This is only one valid case, because MapVector.initializeChildrenFromFields())
return
`EXPR$0::map<key::int32, value::int32>
`I found a place where it start using union - PromotableWriter.promoteToUnion.
And  in the end i have
```
SCHEMA_CHANGE ERROR: Schema changed during projection. Schema was 
schema(EXPR$0::map<key::int32, value::int32>)
 but then changed to 
schema(EXPR$0::map<struct::struct<key::int32, value::int32>, map::map<key::int32, value::int32>>)
```