### PR TITLE
GH-36209: [Java] Upgrade Netty due to security vulnerability (#36211)

### DIFF
--- a/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
+++ b/java/memory/memory-netty/src/main/java/io/netty/buffer/PooledByteBufAllocatorL.java
@@ -161,7 +161,7 @@ public class PooledByteBufAllocatorL {
     }
 
     private UnsafeDirectLittleEndian newDirectBufferL(int initialCapacity, int maxCapacity) {
-      PoolThreadCache cache = threadCache();
+      PoolArenasCache cache = threadCache();
       PoolArena<ByteBuffer> directArena = cache.directArena;
 
       if (directArena != null) {

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -36,7 +36,7 @@
     <dep.netty-bom.version>4.1.94.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.56.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
-    <dep.jackson-bom.version>2.15.1</dep.jackson-bom.version>
+    <dep.jackson-bom.version>2.13.4</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>
     <dep.avro.version>1.10.0</dep.avro.version>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,10 +33,10 @@
     <dep.junit.jupiter.version>5.9.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava-bom.version>31.1-jre</dep.guava-bom.version>
-    <dep.netty-bom.version>4.1.82.Final</dep.netty-bom.version>
-    <dep.grpc-bom.version>1.49.1</dep.grpc-bom.version>
-    <dep.protobuf-bom.version>3.21.6</dep.protobuf-bom.version>
-    <dep.jackson-bom.version>2.13.4</dep.jackson-bom.version>
+    <dep.netty-bom.version>4.1.94.Final</dep.netty-bom.version>
+    <dep.grpc-bom.version>1.56.0</dep.grpc-bom.version>
+    <dep.protobuf-bom.version>3.23.1</dep.protobuf-bom.version>
+    <dep.jackson-bom.version>2.15.1</dep.jackson-bom.version>
     <dep.hadoop.version>2.7.1</dep.hadoop.version>
     <dep.fbs.version>1.12.0</dep.fbs.version>
     <dep.avro.version>1.10.0</dep.avro.version>


### PR DESCRIPTION
Upgrading Netty dependency due to CVE https://github.com/advisories/GHSA-6mjq-h674-j845 This also requires a patch to arrow-memory

Upgrading Netty, gRPC and Protobuf dependencies

Existing tests

No

**This PR contains a "Critical Fix".**

netty-handler SniHandler 16MB allocation

The SniHandler can allocate up to 16MB of heap for each channel during the TLS handshake. When the handler or the channel does not have an idle timeout, it can be used to make a TCP server using the SniHandler to allocate 16MB of heap.

https://github.com/advisories/GHSA-6mjq-h674-j845

* Closes: #36209

Authored-by: Bryan Cutler <cutlerb@gmail.com>