### PR TITLE
DX-61115 handle + sign during parsing +infinity double value

### DIFF
--- a/cpp/src/arrow/vendored/fast_float/parse_number.h
+++ b/cpp/src/arrow/vendored/fast_float/parse_number.h
@@ -30,6 +30,9 @@ from_chars_result parse_infnan(const char *first, const char *last, T &value)  n
       minusSign = true;
       ++first;
   }
+  if (*first == '+') {
+      ++first;
+  }
   if (last - first >= 3) {
     if (fastfloat_strncasecmp(first, "nan", 3)) {
       answer.ptr = (first += 3);


### PR DESCRIPTION
Apache Arrow used [https://github.com/fastfloat/fast_float](fast_float lib). In latest version was added same code but in preprocessing block that undefined by default. Updating to latest version require al lot of code changes inside arrow, ci. So it will be easier to add this block directly to dremio until the version will be updated in apache arrow repo. 