### PR TITLE
DX-67936 Netty 4.1.96 upgrade for CVE-2023-34462 io.netty:netty-handler 4.1.93.Final

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -33,7 +33,7 @@
     <dep.junit.jupiter.version>5.9.0</dep.junit.jupiter.version>
     <dep.slf4j.version>1.7.25</dep.slf4j.version>
     <dep.guava-bom.version>31.1-jre</dep.guava-bom.version>
-    <dep.netty-bom.version>4.1.93.Final</dep.netty-bom.version>
+    <dep.netty-bom.version>4.1.96.Final</dep.netty-bom.version>
     <dep.grpc-bom.version>1.56.0</dep.grpc-bom.version>
     <dep.protobuf-bom.version>3.21.9</dep.protobuf-bom.version>
     <dep.jackson-bom.version>2.13.4</dep.jackson-bom.version>


### PR DESCRIPTION
I ran tpcds for this upgrade using arrow jars built from my personal fork. Looks good: https://jenkins.drem.io/job/AWS-EE-tpcds-perf-jdbc-client/1089/