### PR TITLE
DX-82852: Nullify fieldReader when cleaning up listreader.

### DIFF
--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/ListVector.java
@@ -678,6 +678,7 @@ public class ListVector extends BaseRepeatedValueVector implements PromotableVec
   }
 
   protected void invalidateReader() {
+    fieldReader = null;
     reader = null;
   }
 


### PR DESCRIPTION
After submitting [Cherry pick Gh 15187 into dremio 24.3 12 (#47) · dremio/arrow@c2ad17b](https://github.com/dremio/arrow/commit/c2ad17b03284deb5b36bef3c9cf0a002cef77c07) , Jeremy ran into an issue with a test he was writing failing. WIP: https://gerrit.drem.io/gerrit/c/dremio/+/55212

After extensive debugging Jeremy and I determined that the fieldReader object was being left behind and causing some odd behavior in the unit test.

https://dremio.atlassian.net/browse/DX-82852