### PR TITLE
DX-83326 Update archery/crossbow to work with new version of setuptools.

### DIFF
--- a/dev/archery/archery/crossbow/core.py
+++ b/dev/archery/archery/crossbow/core.py
@@ -740,11 +740,13 @@ def get_version(root, **kwargs):
     subprojects, e.g. apache-arrow-js-XXX tags.
     """
     from setuptools_scm.git import parse as parse_git_version
+    from setuptools_scm import Configuration
 
     # query the calculated version based on the git tags
     kwargs['describe_command'] = (
         'git describe --dirty --tags --long --match "apache-arrow-[0-9]*.*"'
     )
+    kwargs['config'] = Configuration(root=root)
     version = parse_git_version(root, **kwargs)
     tag = str(version.tag)
 


### PR DESCRIPTION
A thirdparty library update in setuptools_scm broke ‘archery’ which is the build system used for building Dremio apache arrow.

The change causing the problem: [correct git workdir passover and setuptools double call in · pypa/setuptools_scm@f7c075a](https://github.com/pypa/setuptools_scm/commit/f7c075a0d9ba724106ebe522831087c16dc15241) 

Archery just uses the latest setuptools_scm which resulted in it pulling in the new version with the change above. https://github.com/dremio/arrow/blob/dremio_24.3_12.0/dev/archery/setup.py#L38