### PR TITLE
temporarily Fix arrow-build issue with newest pygit2.

### DIFF
--- a/dev/archery/setup.py
+++ b/dev/archery/setup.py
@@ -34,7 +34,7 @@ extras = {
     'benchmark': ['pandas'],
     'docker': ['ruamel.yaml', 'python-dotenv'],
     'release': ['pygithub', jinja_req, 'jira', 'semver', 'gitpython'],
-    'crossbow': ['github3.py', jinja_req, 'pygit2>=1.6.0', 'requests',
+    'crossbow': ['github3.py', jinja_req, 'pygit2==1.13.3', 'requests',
                  'ruamel.yaml', 'setuptools_scm'],
     'crossbow-upload': ['github3.py', jinja_req, 'ruamel.yaml',
                         'setuptools_scm'],


### PR DESCRIPTION
pygit2 was updated to 1.14.0 and that broke arrow-build/archery. Temporarily set the pygit2 version to 1.13.3 until a long term fix can be made.