### PR TITLE
GH-40968: [C++][Gandiva] add  RE2::Options set_dot_nl(true) for Like …

### DIFF
--- a/cpp/src/gandiva/regex_functions_holder.cc
+++ b/cpp/src/gandiva/regex_functions_holder.cc
@@ -99,13 +99,14 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const FunctionNode& node) {
           "'like' function requires a string literal as the second parameter"));
 
   RE2::Options regex_op;
+  regex_op.set_dot_nl(true);  // set dotall mode for the regex.
   if (node.descriptor()->name() == "ilike") {
     regex_op.set_case_sensitive(false);  // set case-insensitive for ilike function.
 
     return Make(std::get<std::string>(literal->holder()), regex_op);
   }
   if (node.children().size() == 2) {
-    return Make(std::get<std::string>(literal->holder()));
+    return Make(std::get<std::string>(literal->holder()), regex_op);
   } else {
     auto escape_char = dynamic_cast<LiteralNode*>(node.children().at(2).get());
     ARROW_RETURN_IF(
@@ -118,7 +119,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const FunctionNode& node) {
         Status::Invalid(
             "'like' function requires a string literal as the third parameter"));
     return Make(std::get<std::string>(literal->holder()),
-                std::get<std::string>(escape_char->holder()));
+                std::get<std::string>(escape_char->holder()), regex_op);
   }
 }
 
@@ -126,7 +127,9 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
   std::string pcre_pattern;
   ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
 
-  auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern));
+  RE2::Options regex_op;
+  regex_op.set_dot_nl(true);  // set dotall mode for the regex.
+  auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
   ARROW_RETURN_IF(!lholder->regex_.ok(),
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));
@@ -135,7 +138,8 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
 }
 
 Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_pattern,
-                                                     const std::string& escape_char) {
+                                                     const std::string& escape_char,
+                                                     RE2::Options regex_op) {
   ARROW_RETURN_IF(escape_char.length() > 1,
                   Status::Invalid("The length of escape char ", escape_char,
                                   " in 'like' function is greater than 1"));
@@ -147,7 +151,7 @@ Result<std::shared_ptr<LikeHolder>> LikeHolder::Make(const std::string& sql_patt
     ARROW_RETURN_NOT_OK(RegexUtil::SqlLikePatternToPcre(sql_pattern, pcre_pattern));
   }
 
-  auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern));
+  auto lholder = std::shared_ptr<LikeHolder>(new LikeHolder(pcre_pattern, regex_op));
   ARROW_RETURN_IF(!lholder->regex_.ok(),
                   Status::Invalid("Building RE2 pattern '", pcre_pattern,
                                   "' failed with: ", lholder->regex_.error()));

--- a/cpp/src/gandiva/regex_functions_holder.h
+++ b/cpp/src/gandiva/regex_functions_holder.h
@@ -40,7 +40,8 @@ class GANDIVA_EXPORT LikeHolder : public FunctionHolder {
   static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern);
 
   static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern,
-                                                  const std::string& escape_char);
+                                                  const std::string& escape_char,
+                                                  RE2::Options regex_op);
 
   static Result<std::shared_ptr<LikeHolder>> Make(const std::string& sql_pattern,
                                                   RE2::Options regex_op);


### PR DESCRIPTION
…function (#40970)

### Rationale for this change

Gandiva function "LIKE" does not always work correctly when the string contains \n. String value:
`[function_name: "Space1.protect"\nargs: "passenger_count"\ncolumn_name: "passenger_count" ]` Pattern '%Space1%' nor '%Space1.%' do not match.

### What changes are included in this PR?

added flag set_dot_nl(true) to LikeHolder

### Are these changes tested?

add unit tests.

### Are there any user-facing changes?
Yes

**This PR includes breaking changes to public APIs.**

* GitHub Issue: #40968

Lead-authored-by: Ivan Chesnov <ivan.chesnov@dremio.com>