### PR TITLE
GH-41433: [C++][Gandiva] Fix ascii_utf8 function to return same resul…

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1377,7 +1377,7 @@ gdv_int32 ascii_utf8(const char* data, gdv_int32 data_len) {
   if (data_len == 0) {
     return 0;
   }
-  return static_cast<gdv_int32>(data[0]);
+  return static_cast<gdv_int32>(static_cast<signed char>(data[0]));
 }
 
 // Returns the ASCII character having the binary equivalent to A.

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -51,6 +51,8 @@ TEST(TestStringOps, TestAscii) {
   EXPECT_EQ(ascii_utf8("", 0), 0);
   EXPECT_EQ(ascii_utf8("123", 3), 49);
   EXPECT_EQ(ascii_utf8("999", 3), 57);
+  EXPECT_EQ(ascii_utf8("\x80", 1), -128);
+  EXPECT_EQ(ascii_utf8("\xFF", 1), -1);
 }
 
 TEST(TestStringOps, TestChrBigInt) {


### PR DESCRIPTION
…t on x86 and Arm (#41434)

### Rationale for this change
Fixing ascii_utf8 function that has different return result on x86 and Arm due to default char type sign difference on those platforms. Added tests to cover existing x86 behavior for ascii symbols with code >127.

### What changes are included in this PR?

1. Added type cast to signed char to save existing x86 behavior on Arm platform.
2. Added tests cases for negative results.

### Are these changes tested?
UT included.

### Are there any user-facing changes?
None

* GitHub Issue: #41433

Authored-by: DenisTarasyuk <denis.tarasyuk@dremio.com>