### PR TITLE
GH-38879: [C++][Gandiva] Fix Gandiva to_date function's validation for supress errors parameter (#38987)

### DIFF
--- a/cpp/src/gandiva/to_date_holder.cc
+++ b/cpp/src/gandiva/to_date_holder.cc
@@ -51,7 +51,7 @@ Status ToDateHolder::Make(const FunctionNode& node,
   if (node.children().size() == 3) {
     auto literal_suppress_errors =
         dynamic_cast<LiteralNode*>(node.children().at(2).get());
-    if (literal_pattern == nullptr) {
+    if (literal_suppress_errors == nullptr) {
       return Status::Invalid(
           "The (optional) third parameter to 'to_date' function needs to an integer "
           "literal to indicate whether to suppress the error");

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -62,7 +62,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: ["macos-latest"], arch: "x86_64"}
+          - { runs_on: ["macos-12"], arch: "x86_64"}
     env:
       MACOSX_DEPLOYMENT_TARGET: "10.13"
     steps:
@@ -162,7 +162,7 @@ jobs:
 
   package-jars:
     name: Build jar files
-    runs-on: macos-latest
+    runs-on: macos-12
     needs:
       - build-cpp-ubuntu
       - build-cpp-macos


### PR DESCRIPTION

    * This PR fixes the `to_date_utf8_utf8_int32` gandiva function to avoid crash for invalid input
    
    * A bug fix for to_date_utf8_utf8_int32 parameter validation
    
    Yes, new tests are added to verify non literal input won't crash the to_date_utf8_utf8_int32 function
    
    No
    * Closes: #38879
    
    Authored-by: Yue Ni <niyue.com@gmail.com>
    Signed-off-by: Sutou Kouhei <kou@clear-code.com>