### PR TITLE
Make ComplexVectors support writing of ExtensionType

### DIFF
--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
 import org.apache.arrow.vector.holders.Float2Holder;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/AbstractFieldWriter.java" />
 
@@ -113,7 +114,7 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   public void writeExtensionType(Object var1)  {
     this.fail("ExtensionType");
   }
-  public <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1) {
+  public <T extends ExtensionTypeWriterFactory> void addExtensionTypeFactory(T var1) {
     this.fail("ExtensionType");
   }
 

--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-<@pp.dropOutputFile />
+import org.apache.arrow.vector.holders.Float2Holder;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/AbstractFieldWriter.java" />
 
 
@@ -106,6 +106,17 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
   public void endEntry() {
     throw new IllegalStateException(String.format("You tried to end a map entry when you are using a ValueWriter of type %s.", this.getClass().getSimpleName()));
   }
+
+  public <T extends ExtensionHolder> void write(T var1)  {
+    this.fail("ExtensionType");
+  }
+  public void writeExtensionType(Object var1)  {
+    this.fail("ExtensionType");
+  }
+  public <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1) {
+    this.fail("ExtensionType");
+  }
+
 
   <#list vv.types as type><#list type.minor as minor><#assign name = minor.class?cap_first />
   <#assign fields = minor.fields!type.fields />

--- a/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractFieldWriter.java
@@ -241,6 +241,19 @@ abstract class AbstractFieldWriter extends AbstractBaseWriter implements FieldWr
     fail("Map");
     return null;
   }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    fail("Extension");
+    return null;
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    fail("Extension");
+    return null;
+  }
+  
   <#list vv.types as type><#list type.minor as minor>
   <#assign lowerName = minor.class?uncap_first />
   <#if lowerName == "int" ><#assign lowerName = "integer" /></#if>

--- a/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
+++ b/java/vector/src/main/codegen/templates/AbstractPromotableFieldWriter.java
@@ -284,6 +284,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(arrowType);
+  }
+
+  @Override
   public MapWriter map() {
     return getWriter(MinorType.LIST).map();
   }
@@ -311,6 +316,11 @@ abstract class AbstractPromotableFieldWriter extends AbstractFieldWriter {
   @Override
   public MapWriter map(String name) {
     return getWriter(MinorType.STRUCT).map(name);
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    return getWriter(MinorType.EXTENSIONTYPE).extension(name, arrowType);
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-<@pp.dropOutputFile />
+import org.apache.arrow.vector.holders.ValueHolder;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/writer/BaseWriter.java" />
 
 
@@ -70,7 +70,11 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void end();
   }
 
-  public interface ExtensionWriter extends StructWriter {
+  public interface ExtensionWriter extends BaseWriter {
+    void writeNull();
+    <T extends ExtensionHolder> void write(T var1);
+    void writeExtensionType(Object var1);
+    <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1);
   }
 
   public interface ListWriter extends BaseWriter {

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
 import org.apache.arrow.vector.holders.ValueHolder;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/writer/BaseWriter.java" />
 
@@ -74,7 +75,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     void writeNull();
     <T extends ExtensionHolder> void write(T var1);
     void writeExtensionType(Object var1);
-    <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1);
+    <T extends ExtensionTypeWriterFactory> void addExtensionTypeFactory(T var1);
   }
 
   public interface ListWriter extends BaseWriter {

--- a/java/vector/src/main/codegen/templates/BaseWriter.java
+++ b/java/vector/src/main/codegen/templates/BaseWriter.java
@@ -61,12 +61,16 @@ public interface BaseWriter extends AutoCloseable, Positionable {
 
     void copyReaderToField(String name, FieldReader reader);
     StructWriter struct(String name);
+    ExtensionWriter extension(String name, ArrowType arrowType);
     ListWriter list(String name);
     ListWriter listView(String name);
     MapWriter map(String name);
     MapWriter map(String name, boolean keysSorted);
     void start();
     void end();
+  }
+
+  public interface ExtensionWriter extends StructWriter {
   }
 
   public interface ListWriter extends BaseWriter {
@@ -79,6 +83,7 @@ public interface BaseWriter extends AutoCloseable, Positionable {
     ListWriter listView();
     MapWriter map();
     MapWriter map(boolean keysSorted);
+    ExtensionWriter extension(ArrowType arrowType);
     void copyReader(FieldReader reader);
 
     <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/codegen/templates/PromotableWriter.java
+++ b/java/vector/src/main/codegen/templates/PromotableWriter.java
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-<@pp.dropOutputFile />
+import org.apache.arrow.vector.types.Types.MinorType;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/PromotableWriter.java" />
 
 <#include "/@includes/license.ftl" />
@@ -539,6 +539,16 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   @Override
   public void writeLargeVarChar(String value) {
     getWriter(MinorType.LARGEVARCHAR).writeLargeVarChar(value);
+  }
+
+  @Override
+  public void writeExtensionType(Object value) {
+    getWriter(MinorType.EXTENSIONTYPE).writeExtensionType(value);
+  }
+
+  @Override
+  public <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1) {
+    getWriter(MinorType.EXTENSIONTYPE).addExtensionTypeVisitor(var1);
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/PromotableWriter.java
+++ b/java/vector/src/main/codegen/templates/PromotableWriter.java
@@ -23,6 +23,7 @@
 package org.apache.arrow.vector.complex.impl;
 
 import java.util.Locale;
+import org.apache.arrow.vector.ExtensionTypeVector;
 <#include "/@includes/vv_imports.ftl" />
 
 /**
@@ -285,6 +286,9 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
       case UNION:
         writer = new UnionWriter((UnionVector) vector, nullableStructWriterFactory);
         break;
+      case EXTENSIONTYPE:
+        writer = new UnionExtensionWriter((ExtensionTypeVector) vector);
+        break;  
       default:
         writer = type.getNewFieldWriter(vector);
         break;
@@ -316,6 +320,7 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
         || type == MinorType.MAP
         || type == MinorType.DURATION
         || type == MinorType.FIXEDSIZEBINARY
+        || type == MinorType.EXTENSIONTYPE
         || (type.name().startsWith("TIMESTAMP") && type.name().endsWith("TZ"));
   }
 

--- a/java/vector/src/main/codegen/templates/PromotableWriter.java
+++ b/java/vector/src/main/codegen/templates/PromotableWriter.java
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
 import org.apache.arrow.vector.types.Types.MinorType;<@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/PromotableWriter.java" />
 
@@ -547,8 +548,8 @@ public class PromotableWriter extends AbstractPromotableFieldWriter {
   }
 
   @Override
-  public <T extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(T var1) {
-    getWriter(MinorType.EXTENSIONTYPE).addExtensionTypeVisitor(var1);
+  public <T extends ExtensionTypeWriterFactory> void addExtensionTypeFactory(T var1) {
+    getWriter(MinorType.EXTENSIONTYPE).addExtensionTypeFactory(var1);
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/StructWriters.java
+++ b/java/vector/src/main/codegen/templates/StructWriters.java
@@ -77,6 +77,9 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
         map(child.getName(), arrowType.getKeysSorted());
         break;
       }
+      case EXTENSIONTYPE:
+        extension(child.getName(), child.getType());
+        break;
       case DENSEUNION: {
         FieldType fieldType = new FieldType(addVectorAsNullable, MinorType.DENSEUNION.getType(), null, null);
         DenseUnionWriter writer = new DenseUnionWriter(container.addOrGet(child.getName(), fieldType, DenseUnionVector.class), getNullableStructWriterFactory());
@@ -134,6 +137,29 @@ public class ${mode}StructWriter extends AbstractFieldWriter {
   @Override
   public Field getField() {
       return container.getField();
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    String finalName = handleCase(name);
+    FieldWriter writer = fields.get(finalName);
+    if(writer == null){
+      int vectorCount=container.size();
+      FieldType fieldType = new FieldType(addVectorAsNullable, arrowType, null, null);
+      ExtensionTypeVector vector = container.addOrGet(name, fieldType, ExtensionTypeVector.class);
+      writer = new PromotableWriter(vector, container, getNullableStructWriterFactory());
+      if(vectorCount != container.size()) {
+        writer.allocate();
+      }
+      writer.setPosition(idx());
+      fields.put(finalName, writer);
+    } else {
+      if (writer instanceof PromotableWriter) {
+        // ensure writers are initialized
+        ((PromotableWriter)writer).getWriter(MinorType.EXTENSIONTYPE, arrowType);
+      }
+    }
+    return (ExtensionWriter) writer;
   }
 
   @Override

--- a/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionFixedSizeListWriter.java
@@ -193,6 +193,17 @@ public class UnionFixedSizeListWriter extends AbstractFieldWriter {
   }
 
   @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    writer.extension(arrowType);
+    return writer;
+  }
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    ExtensionWriter extensionWriter = writer.extension(name, arrowType);
+    return extensionWriter;
+  }
+
+  @Override
   public void startList() {
     int start = vector.startNewValue(idx());
     writer.setPosition(start);

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -16,6 +16,7 @@
  */
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.complex.impl.ExtensionTypeWriterFactory;
 import org.apache.arrow.vector.complex.writer.Decimal256Writer;
 import org.apache.arrow.vector.complex.writer.DecimalWriter;
 import org.apache.arrow.vector.holders.Decimal256Holder;
@@ -24,6 +25,8 @@ import org.apache.arrow.vector.holders.DecimalHolder;
 
 import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
+import org.apache.arrow.vector.holders.ExtensionHolder;
+import org.apache.arrow.vector.types.Types.MinorType;
 
 <@pp.dropOutputFile />
 <#list ["List", "ListView", "LargeList", "LargeListView"] as listName>
@@ -332,6 +335,20 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     } else {
       writer.writeNull();
     }
+  }
+
+  @Override
+  public void writeExtensionType(Object value) {
+    writer.writeExtensionType(value);
+  }
+
+  @Override
+  public <T extends ExtensionTypeWriterFactory> void addExtensionTypeFactory(T var1) {
+    writer.addExtensionTypeFactory(var1);
+  }
+
+  public <T extends ExtensionHolder> void write(T var1) {
+    writer.write(var1);
   }
 
   <#list vv.types as type>

--- a/java/vector/src/main/codegen/templates/UnionListWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionListWriter.java
@@ -201,6 +201,17 @@ public class Union${listName}Writer extends AbstractFieldWriter {
     return mapWriter;
   }
 
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    writer.extension(arrowType);
+    return writer;
+  }
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    ExtensionWriter extensionWriter = writer.extension(name, arrowType);
+    return extensionWriter;
+  }
+  
   <#if listName == "LargeList">
   @Override
   public void startList() {

--- a/java/vector/src/main/codegen/templates/UnionMapWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionMapWriter.java
@@ -16,6 +16,8 @@
  */
 
 import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.complex.MapVector;
+import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
 import org.apache.arrow.vector.complex.writer.Decimal256Writer;
 import org.apache.arrow.vector.complex.writer.DecimalWriter;
 import org.apache.arrow.vector.holders.Decimal256Holder;
@@ -23,6 +25,7 @@ import org.apache.arrow.vector.holders.DecimalHolder;
 
 import java.lang.UnsupportedOperationException;
 import java.math.BigDecimal;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 
 <@pp.dropOutputFile />
 <@pp.changeOutputFile name="/org/apache/arrow/vector/complex/impl/UnionMapWriter.java" />
@@ -229,6 +232,18 @@ public class UnionMapWriter extends UnionListWriter {
         return entryWriter.map(MapVector.VALUE_NAME);
       default:
         return super.map();
+    }
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType type) {
+    switch (mode) {
+      case KEY:
+        return entryWriter.extension(MapVector.KEY_NAME, type);
+      case VALUE:
+        return entryWriter.extension(MapVector.VALUE_NAME, type);
+      default:
+        return super.extension(type);
     }
   }
 }

--- a/java/vector/src/main/codegen/templates/UnionWriter.java
+++ b/java/vector/src/main/codegen/templates/UnionWriter.java
@@ -208,6 +208,10 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     return mapWriter;
   }
 
+  private ExtensionWriter getExtensionWriter(ArrowType arrowType) {
+    throw new UnsupportedOperationException("ExtensionTypes are not supported yet.");
+  }
+
   public MapWriter asMap(ArrowType arrowType) {
     data.setType(idx(), MinorType.MAP);
     return getMapWriter(arrowType);
@@ -227,6 +231,8 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
       return getListViewWriter();
     case MAP:
       return getMapWriter(arrowType);
+    case EXTENSIONTYPE:
+      return getExtensionWriter(arrowType);
     <#list vv.types as type>
       <#list type.minor as minor>
         <#assign name = minor.class?cap_first />
@@ -458,6 +464,20 @@ public class UnionWriter extends AbstractFieldWriter implements FieldWriter {
     data.setType(idx(), MinorType.MAP);
     getStructWriter().setPosition(idx());
     return getStructWriter().map(name, keysSorted);
+  }
+
+  @Override
+  public ExtensionWriter extension(ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getListWriter().setPosition(idx());
+    return getListWriter().extension(arrowType);
+  }
+
+  @Override
+  public ExtensionWriter extension(String name, ArrowType arrowType) {
+    data.setType(idx(), MinorType.EXTENSIONTYPE);
+    getStructWriter().setPosition(idx());
+    return getStructWriter().extension(name, arrowType);
   }
 
   <#list vv.types as type><#list type.minor as minor>

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterFactory.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterFactory.java
@@ -18,6 +18,6 @@ package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.ExtensionTypeVector;
 
-public interface ExtensionTypeWriterVisitor<T extends AbstractFieldWriter> {
-  T visit(ExtensionTypeVector vector);
+public interface ExtensionTypeWriterFactory<T extends AbstractFieldWriter> {
+  T getWriterImpl(ExtensionTypeVector vector);
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterVisitor.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/ExtensionTypeWriterVisitor.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.complex.impl;
+
+import org.apache.arrow.vector.ExtensionTypeVector;
+
+public interface ExtensionTypeWriterVisitor<T extends AbstractFieldWriter> {
+  T visit(ExtensionTypeVector vector);
+}

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -61,6 +61,7 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   @Override
   public <S extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(S var1) {
     this.writer = var1.visit(vector);
+    this.writer.setPosition(idx());
   }
 
   public <T extends ExtensionHolder> void write(T var1) {
@@ -70,6 +71,8 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   @Override
   public void setPosition(int index) {
     super.setPosition(index);
-    this.writer.setPosition(index);
+    if (this.writer != null) {
+      this.writer.setPosition(index);
+    }
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -66,4 +66,10 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   public <T extends ExtensionHolder> void write(T var1) {
     this.writer.write(var1);
   }
+
+  @Override
+  public void setPosition(int index) {
+    super.setPosition(index);
+    this.writer.setPosition(index);
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -17,10 +17,12 @@
 package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.holders.ExtensionHolder;
 import org.apache.arrow.vector.types.pojo.Field;
 
 public class UnionExtensionWriter extends AbstractFieldWriter {
   protected ExtensionTypeVector vector;
+  protected AbstractFieldWriter writer;
 
   public UnionExtensionWriter(ExtensionTypeVector vector) {
     this.vector = vector;
@@ -49,5 +51,19 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   @Override
   public void close() throws Exception {
     vector.close();
+  }
+
+  @Override
+  public void writeExtensionType(Object var1) {
+    this.writer.writeExtensionType(var1);
+  }
+
+  @Override
+  public <S extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(S var1) {
+    this.writer = var1.visit(vector);
+  }
+
+  public <T extends ExtensionHolder> void write(T var1) {
+    this.writer.write(var1);
   }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -59,8 +59,8 @@ public class UnionExtensionWriter extends AbstractFieldWriter {
   }
 
   @Override
-  public <S extends ExtensionTypeWriterVisitor> void addExtensionTypeVisitor(S var1) {
-    this.writer = var1.visit(vector);
+  public <S extends ExtensionTypeWriterFactory> void addExtensionTypeFactory(S var1) {
+    this.writer = var1.getWriterImpl(vector);
     this.writer.setPosition(idx());
   }
 

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.arrow.vector.complex.impl;
 
 import org.apache.arrow.vector.ExtensionTypeVector;

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/impl/UnionExtensionWriter.java
@@ -14,20 +14,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.arrow.vector.complex.writer;
 
-import org.apache.arrow.vector.complex.writer.BaseWriter.ExtensionWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ListWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.MapWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.ScalarWriter;
-import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
+package org.apache.arrow.vector.complex.impl;
 
-/**
- * Composite of all writer types. Writers are convenience classes for incrementally adding values to
- * {@linkplain org.apache.arrow.vector.ValueVector}s.
- */
-public interface FieldWriter extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
-  void allocate();
+import org.apache.arrow.vector.ExtensionTypeVector;
+import org.apache.arrow.vector.types.pojo.Field;
 
-  void clear();
+public class UnionExtensionWriter extends AbstractFieldWriter {
+  protected ExtensionTypeVector vector;
+
+  public UnionExtensionWriter(ExtensionTypeVector vector) {
+    this.vector = vector;
+  }
+
+  @Override
+  public void allocate() {
+    vector.allocateNew();
+  }
+
+  @Override
+  public void clear() {
+    vector.clear();
+  }
+
+  @Override
+  public int getValueCapacity() {
+    return vector.getValueCapacity();
+  }
+
+  @Override
+  public Field getField() {
+    return vector.getField();
+  }
+
+  @Override
+  public void close() throws Exception {
+    vector.close();
+  }
 }

--- a/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/complex/writer/FieldWriter.java
@@ -26,7 +26,8 @@ import org.apache.arrow.vector.complex.writer.BaseWriter.StructWriter;
  * Composite of all writer types. Writers are convenience classes for incrementally adding values to
  * {@linkplain org.apache.arrow.vector.ValueVector}s.
  */
-public interface FieldWriter extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
+public interface FieldWriter
+    extends StructWriter, ListWriter, MapWriter, ScalarWriter, ExtensionWriter {
   void allocate();
 
   void clear();

--- a/java/vector/src/main/java/org/apache/arrow/vector/holders/ExtensionHolder.java
+++ b/java/vector/src/main/java/org/apache/arrow/vector/holders/ExtensionHolder.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.arrow.vector.holders;
+
+public abstract class ExtensionHolder implements ValueHolder {
+  public int isSet;
+}

--- a/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/TestStructVector.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.complex.AbstractStructVector;
 import org.apache.arrow.vector.complex.ListVector;
@@ -37,9 +38,11 @@ import org.apache.arrow.vector.complex.writer.IntWriter;
 import org.apache.arrow.vector.holders.ComplexHolder;
 import org.apache.arrow.vector.types.Types;
 import org.apache.arrow.vector.types.Types.MinorType;
+import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.Struct;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.TestExtensionType;
 import org.apache.arrow.vector.util.TransferPair;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -334,6 +337,40 @@ public class TestStructVector {
       assertSame(toVector.getField(), fromVector.getField());
       toVector.clear();
     }
+  }
+
+  @Test
+  public void testStructVectorWithExtensionTypes() {
+    TestExtensionType.UuidType uuidType = new TestExtensionType.UuidType();
+    Field uuidField = new Field("struct_child", FieldType.nullable(uuidType), null);
+    Field structField =
+        new Field("struct", FieldType.nullable(new ArrowType.Struct()), List.of(uuidField));
+    StructVector s1 = new StructVector(structField, allocator, null);
+    StructVector s2 = (StructVector) structField.createVector(allocator);
+    s1.close();
+    s2.close();
+  }
+
+  @Test
+  public void testStructVectorTransferPairWithExtensionType() {
+    TestExtensionType.UuidType uuidType = new TestExtensionType.UuidType();
+    Field uuidField = new Field("uuid_child", FieldType.nullable(uuidType), null);
+    Field structField =
+        new Field("struct", FieldType.nullable(new ArrowType.Struct()), List.of(uuidField));
+
+    StructVector s1 = (StructVector) structField.createVector(allocator);
+    TestExtensionType.UuidVector uuidVector =
+        s1.addOrGet("uuid_child", FieldType.nullable(uuidType), TestExtensionType.UuidVector.class);
+    s1.setValueCount(1);
+    uuidVector.set(0, new UUID(1, 2));
+    s1.setIndexDefined(0);
+
+    TransferPair tp = s1.getTransferPair(structField, allocator);
+    final StructVector toVector = (StructVector) tp.getTo();
+    assertEquals(s1.getField(), toVector.getField());
+
+    s1.close();
+    toVector.close();
   }
 
   private StructVector simpleStructVector(String name, BufferAllocator allocator) {

--- a/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/complex/impl/TestPromotableWriter.java
@@ -26,10 +26,12 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
+import java.util.UUID;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.DecimalVector;
 import org.apache.arrow.vector.DirtyRootAllocator;
+import org.apache.arrow.vector.ExtensionTypeVector;
 import org.apache.arrow.vector.LargeVarBinaryVector;
 import org.apache.arrow.vector.LargeVarCharVector;
 import org.apache.arrow.vector.VarBinaryVector;
@@ -52,6 +54,8 @@ import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.ArrowType.ArrowTypeID;
 import org.apache.arrow.vector.types.pojo.Field;
 import org.apache.arrow.vector.types.pojo.FieldType;
+import org.apache.arrow.vector.types.pojo.TestExtensionType.UuidType;
+import org.apache.arrow.vector.types.pojo.TestExtensionType.UuidVector;
 import org.apache.arrow.vector.util.DecimalUtility;
 import org.apache.arrow.vector.util.Text;
 import org.junit.jupiter.api.AfterEach;
@@ -774,6 +778,97 @@ public class TestPromotableWriter {
 
       assertEquals(1, intHolder.isSet);
       assertEquals(1, intHolder.value);
+    }
+  }
+
+  @Test
+  public void testExtensionType() throws Exception {
+    try (final NonNullableStructVector container =
+            NonNullableStructVector.empty(EMPTY_SCHEMA_PATH, allocator);
+        final UuidVector v =
+            container.addOrGet("uuid", FieldType.nullable(new UuidType()), UuidVector.class);
+        final PromotableWriter writer = new PromotableWriter(v, container)) {
+      UUID u1 = UUID.randomUUID();
+      UUID u2 = UUID.randomUUID();
+      container.allocateNew();
+      container.setValueCount(1);
+      writer.addExtensionTypeFactory(new UuidWriterFactory());
+
+      writer.setPosition(0);
+      writer.writeExtensionType(u1);
+      writer.setPosition(1);
+      writer.writeExtensionType(u2);
+
+      container.setValueCount(2);
+
+      UuidVector uuidVector = (UuidVector) container.getChild("uuid");
+      assertEquals(u1, uuidVector.getObject(0));
+      assertEquals(u2, uuidVector.getObject(1));
+    }
+  }
+
+  public class UuidWriterFactory implements ExtensionTypeWriterFactory {
+
+    @Override
+    public AbstractFieldWriter getWriterImpl(ExtensionTypeVector extensionTypeVector) {
+      if (extensionTypeVector instanceof UuidVector) {
+        return new UuidWriterImpl((UuidVector) extensionTypeVector);
+      }
+      return null;
+    }
+  }
+
+  public class UuidWriterImpl extends AbstractFieldWriter {
+    private final UuidVector vector;
+
+    public UuidWriterImpl(UuidVector vector) {
+      this.vector = vector;
+    }
+
+    @Override
+    public Field getField() {
+      return this.vector.getField();
+    }
+
+    @Override
+    public int getValueCapacity() {
+      return this.vector.getValueCapacity();
+    }
+
+    @Override
+    public void allocate() {
+      this.vector.allocateNew();
+    }
+
+    @Override
+    public void close() {
+      this.vector.close();
+    }
+
+    @Override
+    public void clear() {
+      this.vector.clear();
+    }
+
+    @Override
+    protected int idx() {
+      return super.idx();
+    }
+
+    @Override
+    public void writeExtensionType(Object var1) {
+      UUID uuid = (UUID) var1;
+      ByteBuffer bb = ByteBuffer.allocate(16);
+      bb.putLong(uuid.getMostSignificantBits());
+      bb.putLong(uuid.getLeastSignificantBits());
+      this.vector.setSafe(this.idx(), bb.array());
+      this.vector.setValueCount(this.idx() + 1);
+    }
+
+    @Override
+    public void writeNull() {
+      this.vector.setNull(this.idx());
+      this.vector.setValueCount(this.idx() + 1);
     }
   }
 }

--- a/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
+++ b/java/vector/src/test/java/org/apache/arrow/vector/types/pojo/TestExtensionType.java
@@ -42,6 +42,7 @@ import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.ValueIterableVector;
+import org.apache.arrow.vector.ValueVector;
 import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.compare.Range;
 import org.apache.arrow.vector.compare.RangeEqualsVisitor;
@@ -50,6 +51,7 @@ import org.apache.arrow.vector.ipc.ArrowFileReader;
 import org.apache.arrow.vector.ipc.ArrowFileWriter;
 import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType.ExtensionType;
+import org.apache.arrow.vector.util.TransferPair;
 import org.apache.arrow.vector.util.VectorBatchAppender;
 import org.apache.arrow.vector.validate.ValidateVectorVisitor;
 import org.junit.jupiter.api.Test;
@@ -295,7 +297,7 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidType extends ExtensionType {
+  public static class UuidType extends ExtensionType {
 
     @Override
     public ArrowType storageType() {
@@ -332,12 +334,14 @@ public class TestExtensionType {
     }
   }
 
-  static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
+  public static class UuidVector extends ExtensionTypeVector<FixedSizeBinaryVector>
       implements ValueIterableVector<UUID> {
+    private final Field field;
 
     public UuidVector(
         String name, BufferAllocator allocator, FixedSizeBinaryVector underlyingVector) {
       super(name, allocator, underlyingVector);
+      this.field = new Field(name, FieldType.nullable(new UuidType()), null);
     }
 
     @Override
@@ -361,6 +365,55 @@ public class TestExtensionType {
       bb.putLong(uuid.getMostSignificantBits());
       bb.putLong(uuid.getLeastSignificantBits());
       getUnderlyingVector().set(index, bb.array());
+    }
+
+    @Override
+    public void copyFromSafe(int fromIndex, int thisIndex, ValueVector from) {
+      getUnderlyingVector()
+          .copyFromSafe(fromIndex, thisIndex, ((UuidVector) from).getUnderlyingVector());
+    }
+
+    @Override
+    public Field getField() {
+      return field;
+    }
+
+    @Override
+    public TransferPair makeTransferPair(ValueVector to) {
+      return new TransferImpl((UuidVector) to);
+    }
+
+    public void setSafe(int index, byte[] value) {
+      getUnderlyingVector().setIndexDefined(index);
+      getUnderlyingVector().setSafe(index, value);
+    }
+
+    public class TransferImpl implements TransferPair {
+      UuidVector to;
+      ValueVector targetUnderlyingVector;
+      TransferPair tp;
+
+      public TransferImpl(UuidVector to) {
+        this.to = to;
+        targetUnderlyingVector = this.to.getUnderlyingVector();
+        tp = getUnderlyingVector().makeTransferPair(targetUnderlyingVector);
+      }
+
+      public UuidVector getTo() {
+        return this.to;
+      }
+
+      public void transfer() {
+        tp.transfer();
+      }
+
+      public void splitAndTransfer(int startIndex, int length) {
+        tp.splitAndTransfer(startIndex, length);
+      }
+
+      public void copyValueSafe(int fromIndex, int toIndex) {
+        tp.copyValueSafe(fromIndex, toIndex);
+      }
     }
   }
 


### PR DESCRIPTION
Added writer ExtensionWriter with 3 methods:
- write method  for writing values from Extension holders;
- writeExtensionType method for writing values (arguments is Object because we don't know exact type);
- addExtensionTypeFactory method - because exact vector and value type are unknown, user should create their own extension type vector, writer for it and ExtensionTypeFactory where it should map vector and writer.