### PR TITLE
GH-46708: [C++][Gandiva] Added zero return values for castDECIMAL_utf…

### DIFF
--- a/cpp/src/gandiva/precompiled/decimal_wrapper.cc
+++ b/cpp/src/gandiva/precompiled/decimal_wrapper.cc
@@ -406,6 +406,8 @@ void castDECIMAL_utf8(int64_t context, const char* in, int32_t in_length,
       gdv_fn_dec_from_string(context, in, in_length, &precision_from_str, &scale_from_str,
                              &dec_high_from_str, &dec_low_from_str);
   if (status != 0) {
+    *out_high = 0;
+    *out_low = 0;
     return;
   }
 

--- a/cpp/src/gandiva/tests/decimal_test.cc
+++ b/cpp/src/gandiva/tests/decimal_test.cc
@@ -17,6 +17,7 @@
 
 #include <sstream>
 
+#include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
 #include "arrow/memory_pool.h"
 #include "arrow/status.h"
@@ -1235,5 +1236,45 @@ TEST_F(TestDecimal, TestSha) {
     EXPECT_EQ(value_at_position.size(), sha256_hash_size);
     EXPECT_NE(value_at_position, response->GetScalar(i - 1).ValueOrDie()->ToString());
   }
+}
+
+TEST_F(TestDecimal, TestCastDecimalVarCharInvalidInputInvalidOutput) {
+  auto decimal_type_10_0 = std::make_shared<arrow::Decimal128Type>(10, 0);
+  auto decimal_type_38_30 = std::make_shared<arrow::Decimal128Type>(38, 30);
+  auto decimal_type_38_27 = std::make_shared<arrow::Decimal128Type>(38, 27);
+
+  auto field_str = field("in_str", utf8());
+  auto schema = arrow::schema({field_str});
+  auto res_bool = field("res_bool", arrow::boolean());
+
+  // This is minimal possible expression to reproduce SIGSEGV
+  // equal(multiply(castDecimal(10), castDecimal(100)), castDECIMAL("foo"))
+  auto int_literal = TreeExprBuilder::MakeLiteral(static_cast<int32_t>(100));
+  auto int_literal_multiply = TreeExprBuilder::MakeLiteral(static_cast<int32_t>(10));
+  auto string_literal = TreeExprBuilder::MakeStringLiteral("foo");
+  auto cast_multiply_literal = TreeExprBuilder::MakeFunction(
+      "castDECIMAL", {int_literal_multiply}, decimal_type_10_0);
+  auto cast_int_literal =
+      TreeExprBuilder::MakeFunction("castDECIMAL", {int_literal}, decimal_type_38_30);
+  auto cast_string_func =
+      TreeExprBuilder::MakeFunction("castDECIMAL", {string_literal}, decimal_type_38_30);
+  auto multiply_func = TreeExprBuilder::MakeFunction(
+      "multiply", {cast_multiply_literal, cast_int_literal}, decimal_type_38_27);
+  auto equal_func = TreeExprBuilder::MakeFunction(
+      "equal", {multiply_func, cast_string_func}, arrow::boolean());
+  auto expr = TreeExprBuilder::MakeExpression(equal_func, res_bool);
+
+  std::shared_ptr<Projector> projector;
+
+  ASSERT_OK(Projector::Make(schema, {expr}, TestConfiguration(), &projector));
+
+  int num_records = 1;
+  auto invalid_in = MakeArrowArrayUtf8({"1.345"}, {true});
+  auto in_batch = arrow::RecordBatch::Make(schema, num_records, {invalid_in});
+
+  arrow::ArrayVector outputs;
+  auto status = projector->Evaluate(*in_batch, pool_, &outputs);
+  ASSERT_NOT_OK(status);
+  ASSERT_THAT(status.message(), ::testing::HasSubstr("not a valid decimal128 number"));
 }
 }  // namespace gandiva


### PR DESCRIPTION
…8 (#46709)

### Rationale for this change
castDECIMAL_utf8 has undefined behavior if input value can not be parsed, which causes SIGSEGV for some expressions in Projector. ### What changes are included in this PR?
Setting 0 to out_high, out_low in function castDECIMAL_utf8 to have those values initialised if input value can not be parsed. Added corresponding test that reproduces SIGSEGV in projector. ### Are these changes tested?
Yes
### Are there any user-facing changes?
No

* GitHub Issue: #46708

Authored-by: DenisTarasyuk <denis.tarasyuk@dremio.com>