### PR TITLE
DX-113970 Fix macos build by updating runner and workflow

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -94,8 +94,8 @@ jobs:
         run: ci/scripts/csharp_test.sh $(pwd)
 
   macos:
-    name: AMD64 macOS 13 C# ${{ matrix.dotnet }}
-    runs-on: macos-13
+    name: AMD64 macOS 15 C# ${{ matrix.dotnet }}
+    runs-on: macos-15-intel
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 15
     strategy:

--- a/.github/workflows/java.yml
+++ b/.github/workflows/java.yml
@@ -106,8 +106,8 @@ jobs:
         run: archery docker push ${{ matrix.image }}
 
   macos:
-    name: AMD64 macOS 13 Java JDK ${{ matrix.jdk }}
-    runs-on: macos-13
+    name: AMD64 macOS 15 Java JDK ${{ matrix.jdk }}
+    runs-on: macos-15-intel
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -81,8 +81,8 @@ jobs:
         run: archery docker push debian-js
 
   macos:
-    name: AMD64 macOS 13 NodeJS ${{ matrix.node }}
-    runs-on: macos-13
+    name: AMD64 macOS 15 NodeJS ${{ matrix.node }}
+    runs-on: macos-15-intel
     if: ${{ !contains(github.event.pull_request.title, 'WIP') }}
     timeout-minutes: 30
     strategy:

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -154,8 +154,10 @@ jobs:
           mkdir -p homebrew-custom/Formula
           curl -o homebrew-custom/Formula/cmake.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/f68532bfe5cb87474093df8a839c3818c6aa44dd/Formula/c/cmake.rb
           curl -o homebrew-custom/Formula/boost.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/23f9c56c5075dd56b4471e2c93f89f6400b49ddd/Formula/b/boost.rb
-          brew install -v ./homebrew-custom/Formula/cmake.rb
-          brew install -v ./homebrew-custom/Formula/boost.rb
+          brew tap-new local/homebrew-custom
+          cp ./homebrew-custom/Formula/*.rb "$(brew --repo local/homebrew-custom)/Formula/"
+          brew install -v local/homebrew-custom/cmake
+          brew install -v local/homebrew-custom/boost
           brew pin cmake
           brew pin boost
           #

--- a/dev/tasks/java-jars/github.yml
+++ b/dev/tasks/java-jars/github.yml
@@ -91,7 +91,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: ["macos-13"], arch: "x86_64"}
+          - { runs_on: ["macos-15-intel"], arch: "x86_64"}
     env:
       MACOSX_DEPLOYMENT_TARGET: "12.0"
     steps:
@@ -188,7 +188,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: ["macos-13"], arch: "x86_64"}
+          - { runs_on: ["macos-15-intel"], arch: "x86_64"}
     needs:
       - build-cpp-ubuntu
       - build-cpp-macos

--- a/dev/tasks/r/github.packages.yml
+++ b/dev/tasks/r/github.packages.yml
@@ -66,7 +66,7 @@ jobs:
       fail-fast: false
       matrix:
         platform:
-          - { runs_on: macos-13, arch: "x86_64" }
+          - { runs_on: macos-15-intel, arch: "x86_64" }
           - { runs_on: macos-14, arch: "arm64" }
         openssl: ['3.0', '1.1']
 
@@ -208,7 +208,7 @@ jobs:
       matrix:
         platform:
           - { runs_on: 'windows-latest', name: "Windows"}
-          - { runs_on: macos-13, name: "macOS x86_64"}
+          - { runs_on: macos-15-intel, name: "macOS x86_64"}
           - { runs_on: macos-14, name: "macOS arm64" }
         r_version: [oldrel, release]
     steps:
@@ -389,7 +389,7 @@ jobs:
       matrix:
         platform:
           - {runs_on: "ubuntu-latest", name: "Linux"}
-          - {runs_on: "macos-13" , name: "macOS"}
+          - {runs_on: "macos-15-intel" , name: "macOS"}
     steps:
       - name: Install R
         uses: r-lib/actions/setup-r@v2

--- a/dev/tasks/tasks.yml
+++ b/dev/tasks/tasks.yml
@@ -425,7 +425,7 @@ tasks:
       python_version: "{{ python_version }}"
       python_abi_tag: "{{ abi_tag }}"
       macos_deployment_target: "12.0"
-      runs_on: "macos-13"
+      runs_on: "macos-15-intel"
       vcpkg_arch: "amd64"
     artifacts:
       - pyarrow-{no_rc_version}-{{ python_tag }}-{{ abi_tag }}-macosx_12_0_x86_64.whl
@@ -967,7 +967,7 @@ tasks:
     params:
       target: {{ target }}
       use_conda: True
-      github_runner: "macos-13"
+      github_runner: "macos-15-intel"
   {% endfor %}
 
   {% for target in ["cpp",
@@ -982,7 +982,7 @@ tasks:
     template: verify-rc/github.macos.yml
     params:
       target: {{ target }}
-      github_runner: "macos-13"
+      github_runner: "macos-15-intel"
   {% endfor %}
 
   {% for target in ["cpp",


### PR DESCRIPTION
The build-arrow job is failing: https://github.com/Vijeth-test/arrow-build/actions/runs/22256780098/job/64401087864 with error `The configuration 'macos-13-us-default' is not supported`.

I've checked 26.1 branch and find out these changes: https://github.com/dremio/arrow/pull/104/changes/00f53d47c7b225b57c6a2aee9567e9ca9ae4c1a4 - so I've cherry-picked them to fix the issue. So old macos runner with version 13 is not supported, I've changed to 15

Also faced with another issue after updating macos runnner: https://github.com/Vijeth-test/arrow-build/actions/runs/22379538347/job/64776998677#step:5:240 `Error: Homebrew requires formulae to be in a tap, rejecting:  ./homebrew-custom/Formula/cmake.rb`. I've found such fix: https://github.com/dremio/arrow/commit/45d8010e4be04b0a379e7cda016fb2dcac2c8b4a#diff-c62ecdb3dd583968ea80240bc06da8b8f477220cce4ad11bd1b23d42f8e44894L157-R160 - cherry-picked too