### PR TITLE
[Gandiva] Add timestamp precision support infrastructure and extractYear POC

### DIFF
--- a/cpp/src/gandiva/function_registry_common.h
+++ b/cpp/src/gandiva/function_registry_common.h
@@ -55,6 +55,13 @@ inline DataTypePtr time32() { return arrow::time32(arrow::TimeUnit::MILLI); }
 inline DataTypePtr time64() { return arrow::time64(arrow::TimeUnit::MICRO); }
 
 inline DataTypePtr timestamp() { return arrow::timestamp(arrow::TimeUnit::MILLI); }
+
+// Precision-specific timestamp types for explicit time unit handling
+inline DataTypePtr timestamp_sec() { return arrow::timestamp(arrow::TimeUnit::SECOND); }
+inline DataTypePtr timestamp_ms() { return arrow::timestamp(arrow::TimeUnit::MILLI); }
+inline DataTypePtr timestamp_us() { return arrow::timestamp(arrow::TimeUnit::MICRO); }
+inline DataTypePtr timestamp_ns() { return arrow::timestamp(arrow::TimeUnit::NANO); }
+
 inline DataTypePtr decimal128() { return arrow::decimal128(38, 0); }
 
 struct KeyHash {
@@ -288,6 +295,14 @@ typedef std::unordered_map<const FunctionSignature*, const NativeFunction*, KeyH
 
 // Iterate the inner macro over all time types
 #define TIME_TYPES(INNER, NAME, ALIASES) INNER(NAME, ALIASES, time32)
+
+// Iterate the inner macro over all timestamp precision types
+// These generate precision-specific function registrations
+#define TIMESTAMP_PRECISION_TYPES(INNER, NAME, ALIASES)  \
+  INNER(NAME, ALIASES, timestamp_sec),                   \
+  INNER(NAME, ALIASES, timestamp_ms),                    \
+  INNER(NAME, ALIASES, timestamp_us),                    \
+  INNER(NAME, ALIASES, timestamp_ns)
 
 // Iterate the inner macro over all data types
 #define VAR_LEN_TYPES(INNER, NAME, ALIASES) \

--- a/cpp/src/gandiva/function_registry_datetime.cc
+++ b/cpp/src/gandiva/function_registry_datetime.cc
@@ -47,6 +47,12 @@ namespace gandiva {
 
 #define NEXT_DAY_FNS(name) DATE_TYPES(NEXT_DAY_SAFE_NULL_IF_NULL, name, {})
 
+// Precision-aware extraction function for timestamp types
+// Maps to extractYear_timestamp_sec, extractYear_timestamp_ms, etc.
+#define EXTRACT_TIMESTAMP_PRECISION(NAME, ALIASES, TYPE)                       \
+  NativeFunction(#NAME, std::vector<std::string> ALIASES, DataTypeVector{TYPE()}, \
+                 int64(), kResultNullIfNull, ARROW_STRINGIFY(NAME##_##TYPE))
+
 std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
   static std::vector<NativeFunction> date_time_fn_registry_ = {
       UNARY_SAFE_NULL_NEVER_BOOL(isnull, {}, day_time_interval),
@@ -61,6 +67,9 @@ std::vector<NativeFunction> GetDateTimeFunctionRegistry() {
       TIME_EXTRACTION_FNS(extract),
 
       NEXT_DAY_FNS(next_day),
+
+      // Precision-specific extractYear for all timestamp time units
+      TIMESTAMP_PRECISION_TYPES(EXTRACT_TIMESTAMP_PRECISION, extractYear, {"extract_year"}),
 
       NativeFunction("castDATE", {}, DataTypeVector{utf8()}, date64(), kResultNullIfNull,
                      "castDATE_utf8",

--- a/cpp/src/gandiva/function_signature.cc
+++ b/cpp/src/gandiva/function_signature.cc
@@ -23,6 +23,7 @@
 #include <utility>
 #include <vector>
 
+#include "arrow/type.h"
 #include "arrow/util/checked_cast.h"
 #include "arrow/util/hash_util.h"
 #include "arrow/util/logging.h"
@@ -80,16 +81,58 @@ bool FunctionSignature::operator==(const FunctionSignature& other) const {
   return true;
 }
 
+namespace {
+
+// Helper to get the time unit from temporal types for hashing
+// Returns -1 for non-temporal types
+int GetTemporalTypeUnit(const DataTypePtr& type) {
+  switch (type->id()) {
+    case arrow::Type::TIMESTAMP: {
+      auto ts_type = checked_cast<const arrow::TimestampType*>(type.get());
+      return static_cast<int>(ts_type->unit());
+    }
+    case arrow::Type::TIME32: {
+      auto t32_type = checked_cast<const arrow::Time32Type*>(type.get());
+      return static_cast<int>(t32_type->unit());
+    }
+    case arrow::Type::TIME64: {
+      auto t64_type = checked_cast<const arrow::Time64Type*>(type.get());
+      return static_cast<int>(t64_type->unit());
+    }
+    case arrow::Type::DURATION: {
+      auto dur_type = checked_cast<const arrow::DurationType*>(type.get());
+      return static_cast<int>(dur_type->unit());
+    }
+    default:
+      return -1;
+  }
+}
+
+}  // namespace
+
 /// calculated based on name, datatype id of parameters and datatype id
-/// of return type.
+/// of return type. For temporal types (TIMESTAMP, TIME32, TIME64, DURATION),
+/// also includes the time unit to distinguish different precisions.
 std::size_t FunctionSignature::Hash() const {
   static const size_t kSeedValue = 17;
   size_t result = kSeedValue;
   hash_combine(result, AsciiToLower(base_name_));
   hash_combine(result, static_cast<size_t>(ret_type_->id()));
+
+  // Include time unit for temporal return types
+  int ret_unit = GetTemporalTypeUnit(ret_type_);
+  if (ret_unit >= 0) {
+    hash_combine(result, static_cast<size_t>(ret_unit));
+  }
+
   // not using hash_range since we only want to include the id from the data type
   for (auto& param_type : param_types_) {
     hash_combine(result, static_cast<size_t>(param_type->id()));
+    // Include time unit for temporal parameter types
+    int param_unit = GetTemporalTypeUnit(param_type);
+    if (param_unit >= 0) {
+      hash_combine(result, static_cast<size_t>(param_unit));
+    }
   }
   return result;
 }

--- a/cpp/src/gandiva/function_signature_test.cc
+++ b/cpp/src/gandiva/function_signature_test.cc
@@ -110,4 +110,91 @@ TEST_F(TestFunctionSignature, TestHash) {
   EXPECT_EQ(f3.Hash(), f4.Hash());
 }
 
+TEST_F(TestFunctionSignature, TestTimestampPrecisionHash) {
+  // Different timestamp precisions should have different hashes
+  FunctionSignature ts_sec("extractYear",
+                           {arrow::timestamp(arrow::TimeUnit::SECOND)},
+                           arrow::int64());
+  FunctionSignature ts_ms("extractYear",
+                          {arrow::timestamp(arrow::TimeUnit::MILLI)},
+                          arrow::int64());
+  FunctionSignature ts_us("extractYear",
+                          {arrow::timestamp(arrow::TimeUnit::MICRO)},
+                          arrow::int64());
+  FunctionSignature ts_ns("extractYear",
+                          {arrow::timestamp(arrow::TimeUnit::NANO)},
+                          arrow::int64());
+
+  // All should have different hashes
+  EXPECT_NE(ts_sec.Hash(), ts_ms.Hash());
+  EXPECT_NE(ts_sec.Hash(), ts_us.Hash());
+  EXPECT_NE(ts_sec.Hash(), ts_ns.Hash());
+  EXPECT_NE(ts_ms.Hash(), ts_us.Hash());
+  EXPECT_NE(ts_ms.Hash(), ts_ns.Hash());
+  EXPECT_NE(ts_us.Hash(), ts_ns.Hash());
+
+  // Same precision should have same hash
+  FunctionSignature ts_sec2("extractYear",
+                            {arrow::timestamp(arrow::TimeUnit::SECOND)},
+                            arrow::int64());
+  EXPECT_EQ(ts_sec.Hash(), ts_sec2.Hash());
+}
+
+TEST_F(TestFunctionSignature, TestTimestampPrecisionEquals) {
+  // Different timestamp precisions should NOT be equal
+  FunctionSignature ts_sec("extractYear",
+                           {arrow::timestamp(arrow::TimeUnit::SECOND)},
+                           arrow::int64());
+  FunctionSignature ts_ms("extractYear",
+                          {arrow::timestamp(arrow::TimeUnit::MILLI)},
+                          arrow::int64());
+
+  EXPECT_FALSE(ts_sec == ts_ms);
+
+  // Same precision should be equal
+  FunctionSignature ts_sec2("extractYear",
+                            {arrow::timestamp(arrow::TimeUnit::SECOND)},
+                            arrow::int64());
+  EXPECT_EQ(ts_sec, ts_sec2);
+}
+
+TEST_F(TestFunctionSignature, TestTimestampReturnTypeHash) {
+  // Return type precision should also be distinguished
+  FunctionSignature ret_ms("castTimestamp",
+                           {arrow::utf8()},
+                           arrow::timestamp(arrow::TimeUnit::MILLI));
+  FunctionSignature ret_ns("castTimestamp",
+                           {arrow::utf8()},
+                           arrow::timestamp(arrow::TimeUnit::NANO));
+
+  EXPECT_NE(ret_ms.Hash(), ret_ns.Hash());
+  EXPECT_FALSE(ret_ms == ret_ns);
+}
+
+TEST_F(TestFunctionSignature, TestTime32PrecisionHash) {
+  // Time32 types should also have precision-aware hashing
+  FunctionSignature t32_sec("extractHour",
+                            {arrow::time32(arrow::TimeUnit::SECOND)},
+                            arrow::int64());
+  FunctionSignature t32_ms("extractHour",
+                           {arrow::time32(arrow::TimeUnit::MILLI)},
+                           arrow::int64());
+
+  EXPECT_NE(t32_sec.Hash(), t32_ms.Hash());
+  EXPECT_FALSE(t32_sec == t32_ms);
+}
+
+TEST_F(TestFunctionSignature, TestTime64PrecisionHash) {
+  // Time64 types should also have precision-aware hashing
+  FunctionSignature t64_us("extractHour",
+                           {arrow::time64(arrow::TimeUnit::MICRO)},
+                           arrow::int64());
+  FunctionSignature t64_ns("extractHour",
+                           {arrow::time64(arrow::TimeUnit::NANO)},
+                           arrow::int64());
+
+  EXPECT_NE(t64_us.Hash(), t64_ns.Hash());
+  EXPECT_FALSE(t64_us == t64_ns);
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/epoch_time_point.h
+++ b/cpp/src/gandiva/precompiled/epoch_time_point.h
@@ -24,14 +24,20 @@ bool is_leap_year(int yy);
 bool did_days_overflow(arrow_vendored::date::year_month_day ymd);
 int last_possible_day_in_month(int month, int year);
 
-// A point of time measured in millis since epoch.
-class EpochTimePoint {
+// Template class for precision-aware time point operations.
+// Duration should be one of: std::chrono::seconds, milliseconds, microseconds, nanoseconds
+template <typename Duration>
+class EpochTimePointT {
  public:
-  explicit EpochTimePoint(std::chrono::milliseconds millis_since_epoch)
-      : tp_(millis_since_epoch) {}
+  using duration_type = Duration;
+  using time_point_type =
+      std::chrono::time_point<std::chrono::system_clock, Duration>;
 
-  explicit EpochTimePoint(int64_t millis_since_epoch)
-      : EpochTimePoint(std::chrono::milliseconds(millis_since_epoch)) {}
+  explicit EpochTimePointT(Duration duration_since_epoch)
+      : tp_(duration_since_epoch) {}
+
+  explicit EpochTimePointT(int64_t value_since_epoch)
+      : EpochTimePointT(Duration(value_since_epoch)) {}
 
   int TmYear() const { return static_cast<int>(YearMonthDay().year()) - 1900; }
 
@@ -62,19 +68,29 @@ class EpochTimePoint {
     return static_cast<int>(TimeOfDay().seconds().count());
   }
 
-  EpochTimePoint AddYears(int num_years) const {
-    auto ymd = YearMonthDay() + arrow_vendored::date::years(num_years);
-    return EpochTimePoint((arrow_vendored::date::sys_days{ymd} +  // NOLINT
-                           TimeOfDay().to_duration())
-                              .time_since_epoch());
+  // Returns sub-second component in the native duration unit
+  // For milliseconds: returns 0-999
+  // For microseconds: returns 0-999999
+  // For nanoseconds: returns 0-999999999
+  int64_t SubSeconds() const {
+    auto since_midnight = tp_ - arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+    auto secs = std::chrono::duration_cast<std::chrono::seconds>(since_midnight);
+    return (since_midnight - secs).count();
   }
 
-  EpochTimePoint AddMonths(int num_months) const {
+  EpochTimePointT AddYears(int num_years) const {
+    auto ymd = YearMonthDay() + arrow_vendored::date::years(num_years);
+    return EpochTimePointT(
+        std::chrono::duration_cast<Duration>(
+            (arrow_vendored::date::sys_days{ymd} + TimeOfDayDuration()).time_since_epoch()));
+  }
+
+  EpochTimePointT AddMonths(int num_months) const {
     auto ymd = YearMonthDay() + arrow_vendored::date::months(num_months);
 
-    EpochTimePoint tp = EpochTimePoint((arrow_vendored::date::sys_days{ymd} +  // NOLINT
-                                        TimeOfDay().to_duration())
-                                           .time_since_epoch());
+    EpochTimePointT tp(
+        std::chrono::duration_cast<Duration>(
+            (arrow_vendored::date::sys_days{ymd} + TimeOfDayDuration()).time_since_epoch()));
 
     if (did_days_overflow(ymd)) {
       int days_to_offset =
@@ -86,26 +102,36 @@ class EpochTimePoint {
     return tp;
   }
 
-  EpochTimePoint AddDays(int num_days) const {
-    auto days_since_epoch = arrow_vendored::date::sys_days{YearMonthDay()} +  // NOLINT
+  EpochTimePointT AddDays(int num_days) const {
+    auto days_since_epoch = arrow_vendored::date::sys_days{YearMonthDay()} +
                             arrow_vendored::date::days(num_days);
-    return EpochTimePoint(
-        (days_since_epoch + TimeOfDay().to_duration()).time_since_epoch());
+    return EpochTimePointT(
+        std::chrono::duration_cast<Duration>(
+            (days_since_epoch + TimeOfDayDuration()).time_since_epoch()));
   }
 
-  EpochTimePoint ClearTimeOfDay() const {
-    return EpochTimePoint((tp_ - TimeOfDay().to_duration()).time_since_epoch());
+  EpochTimePointT ClearTimeOfDay() const {
+    return EpochTimePointT(
+        std::chrono::duration_cast<Duration>(
+            (tp_ - TimeOfDayDuration()).time_since_epoch()));
   }
 
-  bool operator==(const EpochTimePoint& other) const { return tp_ == other.tp_; }
+  bool operator==(const EpochTimePointT& other) const { return tp_ == other.tp_; }
 
-  int64_t MillisSinceEpoch() const { return tp_.time_since_epoch().count(); }
+  // Returns the value in the native duration unit
+  int64_t ValueSinceEpoch() const { return tp_.time_since_epoch().count(); }
 
-  arrow_vendored::date::time_of_day<std::chrono::milliseconds> TimeOfDay() const {
-    auto millis_since_midnight =
+  // For backward compatibility with existing code expecting milliseconds
+  int64_t MillisSinceEpoch() const {
+    return std::chrono::duration_cast<std::chrono::milliseconds>(
+               tp_.time_since_epoch())
+        .count();
+  }
+
+  arrow_vendored::date::time_of_day<Duration> TimeOfDay() const {
+    auto duration_since_midnight =
         tp_ - arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
-    return arrow_vendored::date::time_of_day<std::chrono::milliseconds>(
-        millis_since_midnight);
+    return arrow_vendored::date::time_of_day<Duration>(duration_since_midnight);
   }
 
  private:
@@ -114,5 +140,19 @@ class EpochTimePoint {
         arrow_vendored::date::floor<arrow_vendored::date::days>(tp_)};  // NOLINT
   }
 
-  std::chrono::time_point<std::chrono::system_clock, std::chrono::milliseconds> tp_;
+  // Returns time of day as a duration for arithmetic operations
+  Duration TimeOfDayDuration() const {
+    return tp_ - arrow_vendored::date::floor<arrow_vendored::date::days>(tp_);
+  }
+
+  time_point_type tp_;
 };
+
+// Type aliases for each precision level
+using EpochTimePointSec = EpochTimePointT<std::chrono::seconds>;
+using EpochTimePointMilli = EpochTimePointT<std::chrono::milliseconds>;
+using EpochTimePointMicro = EpochTimePointT<std::chrono::microseconds>;
+using EpochTimePointNano = EpochTimePointT<std::chrono::nanoseconds>;
+
+// Backward compatibility: existing code uses EpochTimePoint with milliseconds
+using EpochTimePoint = EpochTimePointMilli;

--- a/cpp/src/gandiva/precompiled/epoch_time_point_test.cc
+++ b/cpp/src/gandiva/precompiled/epoch_time_point_test.cc
@@ -100,4 +100,113 @@ TEST(TestEpochTimePoint, TestClearTimeOfDay) {
             EpochTimePoint(StringToTimestamp("2015-05-05 00:00:00")));
 }
 
+// Tests for precision-aware EpochTimePointT template
+TEST(TestEpochTimePointT, TestAllPrecisionsExtractYear) {
+  // Test date: 2023-06-15 14:30:45.123456789
+  // Unix epoch seconds: 1686839445
+
+  // timestamp[s] - seconds precision
+  EpochTimePointSec tp_sec(1686839445LL);
+  EXPECT_EQ(tp_sec.TmYear() + 1900, 2023);
+  EXPECT_EQ(tp_sec.TmMon() + 1, 6);
+  EXPECT_EQ(tp_sec.TmMday(), 15);
+  EXPECT_EQ(tp_sec.TmHour(), 14);
+  EXPECT_EQ(tp_sec.TmMin(), 30);
+  EXPECT_EQ(tp_sec.TmSec(), 45);
+
+  // timestamp[ms] - milliseconds precision
+  EpochTimePointMilli tp_ms(1686839445123LL);
+  EXPECT_EQ(tp_ms.TmYear() + 1900, 2023);
+  EXPECT_EQ(tp_ms.TmMon() + 1, 6);
+  EXPECT_EQ(tp_ms.TmMday(), 15);
+  EXPECT_EQ(tp_ms.TmHour(), 14);
+  EXPECT_EQ(tp_ms.TmMin(), 30);
+  EXPECT_EQ(tp_ms.TmSec(), 45);
+
+  // timestamp[us] - microseconds precision
+  EpochTimePointMicro tp_us(1686839445123456LL);
+  EXPECT_EQ(tp_us.TmYear() + 1900, 2023);
+  EXPECT_EQ(tp_us.TmMon() + 1, 6);
+  EXPECT_EQ(tp_us.TmMday(), 15);
+  EXPECT_EQ(tp_us.TmHour(), 14);
+  EXPECT_EQ(tp_us.TmMin(), 30);
+  EXPECT_EQ(tp_us.TmSec(), 45);
+
+  // timestamp[ns] - nanoseconds precision
+  EpochTimePointNano tp_ns(1686839445123456789LL);
+  EXPECT_EQ(tp_ns.TmYear() + 1900, 2023);
+  EXPECT_EQ(tp_ns.TmMon() + 1, 6);
+  EXPECT_EQ(tp_ns.TmMday(), 15);
+  EXPECT_EQ(tp_ns.TmHour(), 14);
+  EXPECT_EQ(tp_ns.TmMin(), 30);
+  EXPECT_EQ(tp_ns.TmSec(), 45);
+}
+
+TEST(TestEpochTimePointT, TestSubSeconds) {
+  // timestamp[ms] - subseconds returns milliseconds (0-999)
+  EpochTimePointMilli tp_ms(1686839445123LL);
+  EXPECT_EQ(tp_ms.SubSeconds(), 123);
+
+  // timestamp[us] - subseconds returns microseconds (0-999999)
+  EpochTimePointMicro tp_us(1686839445123456LL);
+  EXPECT_EQ(tp_us.SubSeconds(), 123456);
+
+  // timestamp[ns] - subseconds returns nanoseconds (0-999999999)
+  EpochTimePointNano tp_ns(1686839445123456789LL);
+  EXPECT_EQ(tp_ns.SubSeconds(), 123456789);
+}
+
+TEST(TestEpochTimePointT, TestValueSinceEpoch) {
+  // Each precision should return the original value
+  EpochTimePointSec tp_sec(1686839445LL);
+  EXPECT_EQ(tp_sec.ValueSinceEpoch(), 1686839445LL);
+
+  EpochTimePointMilli tp_ms(1686839445123LL);
+  EXPECT_EQ(tp_ms.ValueSinceEpoch(), 1686839445123LL);
+
+  EpochTimePointMicro tp_us(1686839445123456LL);
+  EXPECT_EQ(tp_us.ValueSinceEpoch(), 1686839445123456LL);
+
+  EpochTimePointNano tp_ns(1686839445123456789LL);
+  EXPECT_EQ(tp_ns.ValueSinceEpoch(), 1686839445123456789LL);
+}
+
+TEST(TestEpochTimePointT, TestMillisSinceEpoch) {
+  // All precisions should convert to milliseconds correctly
+  EpochTimePointSec tp_sec(1686839445LL);
+  EXPECT_EQ(tp_sec.MillisSinceEpoch(), 1686839445000LL);
+
+  EpochTimePointMilli tp_ms(1686839445123LL);
+  EXPECT_EQ(tp_ms.MillisSinceEpoch(), 1686839445123LL);
+
+  EpochTimePointMicro tp_us(1686839445123456LL);
+  EXPECT_EQ(tp_us.MillisSinceEpoch(), 1686839445123LL);
+
+  EpochTimePointNano tp_ns(1686839445123456789LL);
+  EXPECT_EQ(tp_ns.MillisSinceEpoch(), 1686839445123LL);
+}
+
+TEST(TestEpochTimePointT, TestAddDaysPreservesPrecision) {
+  // Adding days should preserve sub-day precision
+  EpochTimePointMicro tp_us(1686839445123456LL);  // 2023-06-15 14:30:45.123456
+  auto tp_us_plus2 = tp_us.AddDays(2);
+  EXPECT_EQ(tp_us_plus2.TmMday(), 17);
+  // Sub-second portion should be preserved
+  EXPECT_EQ(tp_us_plus2.SubSeconds(), 123456);
+
+  EpochTimePointNano tp_ns(1686839445123456789LL);
+  auto tp_ns_plus2 = tp_ns.AddDays(2);
+  EXPECT_EQ(tp_ns_plus2.TmMday(), 17);
+  EXPECT_EQ(tp_ns_plus2.SubSeconds(), 123456789);
+}
+
+TEST(TestEpochTimePointT, TestNegativeTimestamps) {
+  // Before Unix epoch: 1960-06-15 00:00:00
+  // Unix epoch seconds: approximately -301017600
+  EpochTimePointSec tp_sec(-301017600LL);
+  EXPECT_EQ(tp_sec.TmYear() + 1900, 1960);
+  EXPECT_EQ(tp_sec.TmMon() + 1, 6);
+  EXPECT_EQ(tp_sec.TmMday(), 15);
+}
+
 }  // namespace gandiva

--- a/cpp/src/gandiva/precompiled/time.cc
+++ b/cpp/src/gandiva/precompiled/time.cc
@@ -99,6 +99,31 @@ DATE_TYPES(EXTRACT_DECADE)
 
 DATE_TYPES(EXTRACT_YEAR)
 
+// Precision-aware extractYear for all timestamp units
+FORCE_INLINE
+gdv_int64 extractYear_timestamp_sec(gdv_timestamp_sec secs) {
+  EpochTimePointSec tp(secs);
+  return 1900 + tp.TmYear();
+}
+
+FORCE_INLINE
+gdv_int64 extractYear_timestamp_ms(gdv_timestamp_ms millis) {
+  EpochTimePointMilli tp(millis);
+  return 1900 + tp.TmYear();
+}
+
+FORCE_INLINE
+gdv_int64 extractYear_timestamp_us(gdv_timestamp_us micros) {
+  EpochTimePointMicro tp(micros);
+  return 1900 + tp.TmYear();
+}
+
+FORCE_INLINE
+gdv_int64 extractYear_timestamp_ns(gdv_timestamp_ns nanos) {
+  EpochTimePointNano tp(nanos);
+  return 1900 + tp.TmYear();
+}
+
 #define EXTRACT_DOY(TYPE)                            \
   FORCE_INLINE                                       \
   gdv_int64 extractDoy##_##TYPE(gdv_##TYPE millis) { \

--- a/cpp/src/gandiva/precompiled/time_constants.h
+++ b/cpp/src/gandiva/precompiled/time_constants.h
@@ -17,14 +17,62 @@
 
 #pragma once
 
-#define MILLIS_IN_SEC (1000)
-#define MILLIS_IN_MIN (60 * MILLIS_IN_SEC)
-#define MILLIS_IN_HOUR (60 * MILLIS_IN_MIN)
-#define MILLIS_IN_DAY (24 * MILLIS_IN_HOUR)
-#define MILLIS_IN_WEEK (7 * MILLIS_IN_DAY)
+// Millisecond-based constants (existing)
+#define MILLIS_IN_SEC (1000LL)
+#define MILLIS_IN_MIN (60LL * MILLIS_IN_SEC)
+#define MILLIS_IN_HOUR (60LL * MILLIS_IN_MIN)
+#define MILLIS_IN_DAY (24LL * MILLIS_IN_HOUR)
+#define MILLIS_IN_WEEK (7LL * MILLIS_IN_DAY)
 
+// Microsecond-based constants
+#define MICROS_IN_MILLI (1000LL)
+#define MICROS_IN_SEC (1000000LL)
+#define MICROS_IN_MIN (60LL * MICROS_IN_SEC)
+#define MICROS_IN_HOUR (60LL * MICROS_IN_MIN)
+#define MICROS_IN_DAY (24LL * MICROS_IN_HOUR)
+#define MICROS_IN_WEEK (7LL * MICROS_IN_DAY)
+
+// Nanosecond-based constants
+#define NANOS_IN_MICRO (1000LL)
+#define NANOS_IN_MILLI (1000000LL)
+#define NANOS_IN_SEC (1000000000LL)
+#define NANOS_IN_MIN (60LL * NANOS_IN_SEC)
+#define NANOS_IN_HOUR (60LL * NANOS_IN_MIN)
+#define NANOS_IN_DAY (24LL * NANOS_IN_HOUR)
+#define NANOS_IN_WEEK (7LL * NANOS_IN_DAY)
+
+// Seconds-based constants
+#define SECS_IN_MIN (60LL)
+#define SECS_IN_HOUR (60LL * SECS_IN_MIN)
+#define SECS_IN_DAY (24LL * SECS_IN_HOUR)
+#define SECS_IN_WEEK (7LL * SECS_IN_DAY)
+
+// Millisecond conversion macros (existing)
 #define MILLIS_TO_SEC(millis) ((millis) / MILLIS_IN_SEC)
 #define MILLIS_TO_MINS(millis) ((millis) / MILLIS_IN_MIN)
 #define MILLIS_TO_HOUR(millis) ((millis) / MILLIS_IN_HOUR)
 #define MILLIS_TO_DAY(millis) ((millis) / MILLIS_IN_DAY)
 #define MILLIS_TO_WEEK(millis) ((millis) / MILLIS_IN_WEEK)
+
+// Microsecond conversion macros
+#define MICROS_TO_SEC(micros) ((micros) / MICROS_IN_SEC)
+#define MICROS_TO_MINS(micros) ((micros) / MICROS_IN_MIN)
+#define MICROS_TO_HOUR(micros) ((micros) / MICROS_IN_HOUR)
+#define MICROS_TO_DAY(micros) ((micros) / MICROS_IN_DAY)
+#define MICROS_TO_MILLIS(micros) ((micros) / MICROS_IN_MILLI)
+
+// Nanosecond conversion macros
+#define NANOS_TO_SEC(nanos) ((nanos) / NANOS_IN_SEC)
+#define NANOS_TO_MINS(nanos) ((nanos) / NANOS_IN_MIN)
+#define NANOS_TO_HOUR(nanos) ((nanos) / NANOS_IN_HOUR)
+#define NANOS_TO_DAY(nanos) ((nanos) / NANOS_IN_DAY)
+#define NANOS_TO_MILLIS(nanos) ((nanos) / NANOS_IN_MILLI)
+#define NANOS_TO_MICROS(nanos) ((nanos) / NANOS_IN_MICRO)
+
+// Upward conversion macros
+#define SECS_TO_MILLIS(secs) ((secs) * MILLIS_IN_SEC)
+#define SECS_TO_MICROS(secs) ((secs) * MICROS_IN_SEC)
+#define SECS_TO_NANOS(secs) ((secs) * NANOS_IN_SEC)
+#define MILLIS_TO_MICROS(millis) ((millis) * MICROS_IN_MILLI)
+#define MILLIS_TO_NANOS(millis) ((millis) * NANOS_IN_MILLI)
+#define MICROS_TO_NANOS(micros) ((micros) * NANOS_IN_MICRO)

--- a/cpp/src/gandiva/precompiled/time_test.cc
+++ b/cpp/src/gandiva/precompiled/time_test.cc
@@ -327,6 +327,46 @@ TEST(TestTime, TestExtractTimestamp) {
   EXPECT_EQ(extractSecond_timestamp(ts), 33);
 }
 
+TEST(TestTime, TestExtractYearTimestampPrecisions) {
+  // Test date: 2023-06-15 14:30:45.123456789
+  // Unix epoch seconds: 1686839445
+  constexpr int64_t epoch_sec = 1686839445LL;
+
+  // Test extractYear with seconds precision
+  EXPECT_EQ(extractYear_timestamp_sec(epoch_sec), 2023);
+
+  // Test extractYear with milliseconds precision
+  EXPECT_EQ(extractYear_timestamp_ms(epoch_sec * 1000 + 123), 2023);
+
+  // Test extractYear with microseconds precision
+  EXPECT_EQ(extractYear_timestamp_us(epoch_sec * 1000000 + 123456), 2023);
+
+  // Test extractYear with nanoseconds precision
+  EXPECT_EQ(extractYear_timestamp_ns(epoch_sec * 1000000000LL + 123456789), 2023);
+
+  // Test year boundaries
+  // 1999-12-31 23:59:59 UTC -> should be 1999
+  constexpr int64_t dec31_1999_sec = 946684799LL;
+  EXPECT_EQ(extractYear_timestamp_sec(dec31_1999_sec), 1999);
+
+  // 2000-01-01 00:00:00 UTC -> should be 2000
+  constexpr int64_t jan1_2000_sec = 946684800LL;
+  EXPECT_EQ(extractYear_timestamp_sec(jan1_2000_sec), 2000);
+
+  // Test with different precisions for the same moment
+  EXPECT_EQ(extractYear_timestamp_ms(jan1_2000_sec * 1000), 2000);
+  EXPECT_EQ(extractYear_timestamp_us(jan1_2000_sec * 1000000), 2000);
+  EXPECT_EQ(extractYear_timestamp_ns(jan1_2000_sec * 1000000000LL), 2000);
+
+  // Test negative timestamps (before 1970)
+  // 1960-06-15 00:00:00 UTC
+  constexpr int64_t jun15_1960_sec = -301017600LL;
+  EXPECT_EQ(extractYear_timestamp_sec(jun15_1960_sec), 1960);
+  EXPECT_EQ(extractYear_timestamp_ms(jun15_1960_sec * 1000), 1960);
+  EXPECT_EQ(extractYear_timestamp_us(jun15_1960_sec * 1000000), 1960);
+  EXPECT_EQ(extractYear_timestamp_ns(jun15_1960_sec * 1000000000LL), 1960);
+}
+
 TEST(TestTime, TimeStampTrunc) {
   EXPECT_EQ(date_trunc_Second_date64(StringToTimestamp("2015-05-05 10:20:34")),
             StringToTimestamp("2015-05-05 10:20:34"));

--- a/cpp/src/gandiva/precompiled/types.h
+++ b/cpp/src/gandiva/precompiled/types.h
@@ -37,6 +37,14 @@ using gdv_date64 = int64_t;
 using gdv_date32 = int32_t;
 using gdv_time32 = int32_t;
 using gdv_timestamp = int64_t;
+
+// Precision-specific timestamp type aliases
+// All are int64_t but document the expected unit for clarity
+using gdv_timestamp_sec = int64_t;   // seconds since epoch
+using gdv_timestamp_ms = int64_t;    // milliseconds since epoch
+using gdv_timestamp_us = int64_t;    // microseconds since epoch
+using gdv_timestamp_ns = int64_t;    // nanoseconds since epoch
+
 using gdv_utf8 = char*;
 using gdv_binary = char*;
 using gdv_day_time_interval = int64_t;
@@ -58,6 +66,11 @@ gdv_int64 extractMillennium_timestamp(gdv_timestamp millis);
 gdv_int64 extractCentury_timestamp(gdv_timestamp millis);
 gdv_int64 extractDecade_timestamp(gdv_timestamp millis);
 gdv_int64 extractYear_timestamp(gdv_timestamp millis);
+// Precision-specific extractYear declarations
+gdv_int64 extractYear_timestamp_sec(gdv_timestamp_sec secs);
+gdv_int64 extractYear_timestamp_ms(gdv_timestamp_ms millis);
+gdv_int64 extractYear_timestamp_us(gdv_timestamp_us micros);
+gdv_int64 extractYear_timestamp_ns(gdv_timestamp_ns nanos);
 gdv_int64 extractDoy_timestamp(gdv_timestamp millis);
 gdv_int64 extractQuarter_timestamp(gdv_timestamp millis);
 gdv_int64 extractMonth_timestamp(gdv_timestamp millis);

--- a/cpp/src/gandiva/tests/date_time_test.cc
+++ b/cpp/src/gandiva/tests/date_time_test.cc
@@ -828,4 +828,77 @@ TEST_F(DateTimeTestProjector, TestFromUtcTimestamp) {
   // Validate results
   EXPECT_ARROW_ARRAY_EQUALS(exp_output, outputs.at(0));
 }
+
+TEST_F(DateTimeTestProjector, TestExtractYearTimestampPrecisions) {
+  // Test that extractYear works correctly with all 4 timestamp precisions
+  auto field_ts_sec = field("ts_sec", timestamp(arrow::TimeUnit::SECOND));
+  auto field_ts_ms = field("ts_ms", timestamp(arrow::TimeUnit::MILLI));
+  auto field_ts_us = field("ts_us", timestamp(arrow::TimeUnit::MICRO));
+  auto field_ts_ns = field("ts_ns", timestamp(arrow::TimeUnit::NANO));
+  auto schema = arrow::schema({field_ts_sec, field_ts_ms, field_ts_us, field_ts_ns});
+
+  // Output fields
+  auto field_year_sec = field("year_sec", int64());
+  auto field_year_ms = field("year_ms", int64());
+  auto field_year_us = field("year_us", int64());
+  auto field_year_ns = field("year_ns", int64());
+
+  // Build expressions for each precision
+  auto expr_sec =
+      TreeExprBuilder::MakeExpression("extractYear", {field_ts_sec}, field_year_sec);
+  auto expr_ms =
+      TreeExprBuilder::MakeExpression("extractYear", {field_ts_ms}, field_year_ms);
+  auto expr_us =
+      TreeExprBuilder::MakeExpression("extractYear", {field_ts_us}, field_year_us);
+  auto expr_ns =
+      TreeExprBuilder::MakeExpression("extractYear", {field_ts_ns}, field_year_ns);
+
+  // Build projector
+  std::shared_ptr<Projector> projector;
+  auto status = Projector::Make(schema, {expr_sec, expr_ms, expr_us, expr_ns},
+                                TestConfiguration(), &projector);
+  ASSERT_OK(status);
+
+  // Test data: 2023-06-15 14:30:45.123456789
+  // Unix epoch seconds: 1686839445
+  constexpr int64_t epoch_sec = 1686839445LL;
+  constexpr int num_records = 3;
+
+  // Input arrays with different values to test year extraction
+  // 2023-06-15, 1999-12-31, 2000-01-01
+  constexpr int64_t dec31_1999_sec = 946684799LL;
+  constexpr int64_t jan1_2000_sec = 946684800LL;
+
+  auto array_sec =
+      MakeArrowArrayInt64({epoch_sec, dec31_1999_sec, jan1_2000_sec}, {true, true, true});
+  auto array_ms = MakeArrowArrayInt64(
+      {epoch_sec * 1000 + 123, dec31_1999_sec * 1000, jan1_2000_sec * 1000},
+      {true, true, true});
+  auto array_us = MakeArrowArrayInt64(
+      {epoch_sec * 1000000 + 123456, dec31_1999_sec * 1000000, jan1_2000_sec * 1000000},
+      {true, true, true});
+  auto array_ns = MakeArrowArrayInt64({epoch_sec * 1000000000LL + 123456789,
+                                       dec31_1999_sec * 1000000000LL,
+                                       jan1_2000_sec * 1000000000LL},
+                                      {true, true, true});
+
+  // Create record batch
+  auto in_batch =
+      arrow::RecordBatch::Make(schema, num_records, {array_sec, array_ms, array_us, array_ns});
+
+  // Evaluate
+  arrow::ArrayVector outputs;
+  status = projector->Evaluate(*in_batch, pool_, &outputs);
+  ASSERT_OK(status);
+
+  // Expected results: 2023, 1999, 2000 for all precisions
+  auto exp_years = MakeArrowArrayInt64({2023, 1999, 2000}, {true, true, true});
+
+  // All precisions should give the same year values
+  EXPECT_ARROW_ARRAY_EQUALS(exp_years, outputs.at(0));  // seconds
+  EXPECT_ARROW_ARRAY_EQUALS(exp_years, outputs.at(1));  // milliseconds
+  EXPECT_ARROW_ARRAY_EQUALS(exp_years, outputs.at(2));  // microseconds
+  EXPECT_ARROW_ARRAY_EQUALS(exp_years, outputs.at(3));  // nanoseconds
+}
+
 }  // namespace gandiva


### PR DESCRIPTION
## Summary

This PR adds core infrastructure for supporting all four timestamp precisions (SECOND, MILLISECOND, MICROSECOND, NANOSECOND) in Gandiva, along with a proof-of-concept implementation for `extractYear`.

## Changes

### Phase 1: Core Infrastructure
- Add `MICROS_*`, `NANOS_*`, `SECS_*` constants to `time_constants.h`
- Create templated `EpochTimePointT<Duration>` class for precision-aware time operations
- Add `gdv_timestamp_{sec,ms,us,ns}` type aliases in `types.h`
- Update `FunctionSignature::Hash()` to include TimeUnit for temporal types
- Add `timestamp_{sec,ms,us,ns}()` helpers and `TIMESTAMP_PRECISION_TYPES` macro

### Phase 2: Proof of Concept - extractYear
- Implement `extractYear_timestamp_{sec,ms,us,ns}` functions
- Register precision-specific extractYear in function registry
- Add unit tests for `EpochTimePointT` template
- Add unit tests for precision-specific extractYear
- Add FunctionSignature hash tests for timestamp precisions
- Add integration test for extractYear with all precisions

## Motivation

Currently, Gandiva internally operates on milliseconds for most timestamp functions, which can lead to precision loss when working with microsecond or nanosecond timestamps. This PR establishes the foundation for native multi-precision support.

## Testing

- Unit tests for `EpochTimePointT` template with all precisions
- Unit tests for `extractYear` with all precisions
- FunctionSignature hash tests verifying precision differentiation
- Integration tests with Gandiva Projector

---
Co-authored by [Augment Code](https://www.augmentcode.com)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author