### PR TITLE
Fix CI: resolve pre-commit lint, compilation, and environment failures

### DIFF
--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -45,7 +45,6 @@ fi
 : ${PIPX_PYTHON:=${PIPX_BASE_PYTHON:-$(which python3)}}
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
-${PIPX_BASE_PYTHON} -m pip install setuptools
 ${PIPX_BASE_PYTHON} -m pip install -U pipx
 
 pipx_flags=(--verbose --python ${PIPX_PYTHON})
@@ -53,8 +52,13 @@ if [[ $(id -un) == "root" ]]; then
   # Install globally as /root/.local/bin is typically not in $PATH
   pipx_flags+=(--global)
 fi
+# Prefer pre-built binary wheels to avoid building grpcio (and other C extensions)
+# from source, which requires build tools like setuptools/pkg_resources that may
+# not be available in isolated build environments.
+pip_extra_args="--prefer-binary"
 if [[ -n "${PIPX_PIP_ARGS}" ]]; then
-  pipx_flags+=(--pip-args "'${PIPX_PIP_ARGS}'")
+  pip_extra_args="${pip_extra_args} ${PIPX_PIP_ARGS}"
 fi
+pipx_flags+=(--pip-args "${pip_extra_args}")
 ${PIPX_BASE_PYTHON} -m pipx install ${pipx_flags[@]} \
   "https://github.com/googleapis/storage-testbench/archive/${version}.tar.gz"

--- a/ci/scripts/install_gcs_testbench.sh
+++ b/ci/scripts/install_gcs_testbench.sh
@@ -45,6 +45,7 @@ fi
 : ${PIPX_PYTHON:=${PIPX_BASE_PYTHON:-$(which python3)}}
 
 export PIP_BREAK_SYSTEM_PACKAGES=1
+${PIPX_BASE_PYTHON} -m pip install setuptools
 ${PIPX_BASE_PYTHON} -m pip install -U pipx
 
 pipx_flags=(--verbose --python ${PIPX_PYTHON})

--- a/ci/scripts/msys2_setup.sh
+++ b/ci/scripts/msys2_setup.sh
@@ -48,6 +48,7 @@ case "${target}" in
     packages+=(${MINGW_PACKAGE_PREFIX}-snappy)
     packages+=(${MINGW_PACKAGE_PREFIX}-sqlite3)
     packages+=(${MINGW_PACKAGE_PREFIX}-thrift)
+    packages+=(${MINGW_PACKAGE_PREFIX}-llvm)
     packages+=(${MINGW_PACKAGE_PREFIX}-xsimd)
     packages+=(${MINGW_PACKAGE_PREFIX}-uriparser)
     packages+=(${MINGW_PACKAGE_PREFIX}-zstd)

--- a/ci/vcpkg/overlay/brotli/portfile.cmake
+++ b/ci/vcpkg/overlay/brotli/portfile.cmake
@@ -1,16 +1,15 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO google/brotli
-    REF "v${VERSION}"
-    SHA512 0b5c374417938eae11101995a373d30b1c91212e901e787b6e4b620195247ee754a3a4abda82793582be0b5fbe9dafca2da0b90e1341b3b91641c27cde6d42de1
-    HEAD_REF master
-)
+vcpkg_from_github(OUT_SOURCE_PATH
+                  SOURCE_PATH
+                  REPO
+                  google/brotli
+                  REF
+                  "v${VERSION}"
+                  SHA512
+                  0b5c374417938eae11101995a373d30b1c91212e901e787b6e4b620195247ee754a3a4abda82793582be0b5fbe9dafca2da0b90e1341b3b91641c27cde6d42de1
+                  HEAD_REF
+                  master)
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DBROTLI_BUNDLED_MODE=ON
-)
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}" OPTIONS -DBROTLI_BUNDLED_MODE=ON)
 
 vcpkg_cmake_install()
 
@@ -23,9 +22,8 @@ file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/share/brotli")
 # Skip copying tools in debug builds - the brotli executable is not built in debug mode
 # Only copy tools if VCPKG_BUILD_TYPE is not set to debug
 if(NOT VCPKG_BUILD_TYPE STREQUAL "debug")
-    vcpkg_copy_tools(TOOL_NAMES brotli AUTO_CLEAN)
+  vcpkg_copy_tools(TOOL_NAMES brotli AUTO_CLEAN)
 endif()
 
 # Handle copyright
 vcpkg_install_copyright("${SOURCE_PATH}/LICENSE")
-

--- a/ci/vcpkg/overlay/llvm/portfile.cmake
+++ b/ci/vcpkg/overlay/llvm/portfile.cmake
@@ -6,44 +6,58 @@ vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 set(VCPKG_BUILD_TYPE release)
 
 # [BOLT] Allow to compile with MSVC (#151189)
-vcpkg_download_distfile(
-    PATCH1_FILE
-    URLS https://github.com/llvm/llvm-project/commit/497d17737518d417f6411d46aef1334f642ccd81.patch?full_index=1
-    SHA512 7bf4d4ee8f72fea5b8094320d1f3a71063ec19fe1b552424182c4140055bf6aacfa9ff64b0bcab0a8d6739e4b6249641f58d19fb6b35e1ada67b66b53776dc1a
-    FILENAME 497d17737518d417f6411d46aef1334f642ccd81.patch
-)
+vcpkg_download_distfile(PATCH1_FILE
+                        URLS
+                        https://github.com/llvm/llvm-project/commit/497d17737518d417f6411d46aef1334f642ccd81.patch?full_index=1
+                        SHA512
+                        7bf4d4ee8f72fea5b8094320d1f3a71063ec19fe1b552424182c4140055bf6aacfa9ff64b0bcab0a8d6739e4b6249641f58d19fb6b35e1ada67b66b53776dc1a
+                        FILENAME
+                        497d17737518d417f6411d46aef1334f642ccd81.patch)
 
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO llvm/llvm-project
-    REF "llvmorg-${VERSION}"
-    SHA512 85d272761253428b648f3d111b7308f8cdee74cceebec9e709126c4555ad1e78c443183ad8eb7319e0a15bafb97868ab5b5a3d86ba64812750c568dbf715d8ec
-    HEAD_REF main
-    PATCHES
-        0001-fix-install-package-dir.patch
-        0002-fix-tools-install-dir.patch
-        0003-fix-llvm-config.patch
-        0004-disable-libomp-aliases.patch
-        0005-fix-runtimes.patch
-        0006-create-destination-mlir-directory.patch
-        "${PATCH1_FILE}"
-)
+vcpkg_from_github(OUT_SOURCE_PATH
+                  SOURCE_PATH
+                  REPO
+                  llvm/llvm-project
+                  REF
+                  "llvmorg-${VERSION}"
+                  SHA512
+                  85d272761253428b648f3d111b7308f8cdee74cceebec9e709126c4555ad1e78c443183ad8eb7319e0a15bafb97868ab5b5a3d86ba64812750c568dbf715d8ec
+                  HEAD_REF
+                  main
+                  PATCHES
+                  0001-fix-install-package-dir.patch
+                  0002-fix-tools-install-dir.patch
+                  0003-fix-llvm-config.patch
+                  0004-disable-libomp-aliases.patch
+                  0005-fix-runtimes.patch
+                  0006-create-destination-mlir-directory.patch
+                  "${PATCH1_FILE}")
 
-vcpkg_check_features(
-    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        tools LLVM_BUILD_TOOLS
-        tools LLVM_INCLUDE_TOOLS
-        utils LLVM_BUILD_UTILS
-        utils LLVM_INCLUDE_UTILS
-        utils LLVM_INSTALL_UTILS
-        enable-assertions LLVM_ENABLE_ASSERTIONS
-        enable-rtti LLVM_ENABLE_RTTI
-        enable-ffi LLVM_ENABLE_FFI
-        enable-eh LLVM_ENABLE_EH
-        enable-bindings LLVM_ENABLE_BINDINGS
-        export-symbols LLVM_EXPORT_SYMBOLS_FOR_PLUGINS
-)
+vcpkg_check_features(OUT_FEATURE_OPTIONS
+                     FEATURE_OPTIONS
+                     FEATURES
+                     tools
+                     LLVM_BUILD_TOOLS
+                     tools
+                     LLVM_INCLUDE_TOOLS
+                     utils
+                     LLVM_BUILD_UTILS
+                     utils
+                     LLVM_INCLUDE_UTILS
+                     utils
+                     LLVM_INSTALL_UTILS
+                     enable-assertions
+                     LLVM_ENABLE_ASSERTIONS
+                     enable-rtti
+                     LLVM_ENABLE_RTTI
+                     enable-ffi
+                     LLVM_ENABLE_FFI
+                     enable-eh
+                     LLVM_ENABLE_EH
+                     enable-bindings
+                     LLVM_ENABLE_BINDINGS
+                     export-symbols
+                     LLVM_EXPORT_SYMBOLS_FOR_PLUGINS)
 
 vcpkg_cmake_get_vars(cmake_vars_file)
 include("${cmake_vars_file}")
@@ -52,30 +66,21 @@ include("${cmake_vars_file}")
 # LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON disables this error.
 # See https://developercommunity.visualstudio.com/content/problem/845933/miscompile-boolean-condition-deduced-to-be-always.html
 # and thread "[llvm-dev] Longstanding failing tests - clang-tidy, MachO, Polly" on llvm-dev Jan 21-23 2020.
-if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_DETECTED_MSVC_VERSION LESS "1925")
-    list(APPEND FEATURE_OPTIONS
-        -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON
-    )
+if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_DETECTED_MSVC_VERSION
+                                                            LESS "1925")
+  list(APPEND FEATURE_OPTIONS -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON)
 endif()
 
 # Force enable or disable external libraries
-set(llvm_external_libraries
-    zlib
-    libxml2
-    zstd
-)
+set(llvm_external_libraries zlib libxml2 zstd)
 foreach(external_library IN LISTS llvm_external_libraries)
-    string(TOLOWER "enable-${external_library}" feature_name)
-    string(TOUPPER "LLVM_ENABLE_${external_library}" define_name)
-    if(feature_name IN_LIST FEATURES)
-        list(APPEND FEATURE_OPTIONS
-            -D${define_name}=FORCE_ON
-        )
-    else()
-        list(APPEND FEATURE_OPTIONS
-            -D${define_name}=OFF
-        )
-    endif()
+  string(TOLOWER "enable-${external_library}" feature_name)
+  string(TOUPPER "LLVM_ENABLE_${external_library}" define_name)
+  if(feature_name IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -D${define_name}=FORCE_ON)
+  else()
+    list(APPEND FEATURE_OPTIONS -D${define_name}=OFF)
+  endif()
 endforeach()
 
 # LLVM_ABI_BREAKING_CHECKS can be WITH_ASSERTS (default), FORCE_ON or FORCE_OFF.
@@ -84,127 +89,115 @@ endforeach()
 # baked into the header files; thus, we always turn off LLVM_ABI_BREAKING_CHECKS
 # unless the user asks for it
 if("enable-abi-breaking-checks" IN_LIST FEATURES)
-    # Force enable abi-breaking checks.
-    list(APPEND FEATURE_OPTIONS
-        -DLLVM_ABI_BREAKING_CHECKS=FORCE_ON
-    )
+  # Force enable abi-breaking checks.
+  list(APPEND FEATURE_OPTIONS -DLLVM_ABI_BREAKING_CHECKS=FORCE_ON)
 else()
-    # Force disable abi-breaking checks.
-    list(APPEND FEATURE_OPTIONS
-        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
-    )
+  # Force disable abi-breaking checks.
+  list(APPEND FEATURE_OPTIONS -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF)
 endif()
 
 # All projects: bolt;clang;clang-tools-extra;lld;lldb;mlir;polly
 # Extra projects: flang
 set(LLVM_ENABLE_PROJECTS)
 if("bolt" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "bolt")
-    list(APPEND FEATURE_OPTIONS
-        -DBOLT_TOOLS_INSTALL_DIR:PATH=tools/llvm
-    )
+  list(APPEND LLVM_ENABLE_PROJECTS "bolt")
+  list(APPEND FEATURE_OPTIONS -DBOLT_TOOLS_INSTALL_DIR:PATH=tools/llvm)
 endif()
 if("clang" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "clang")
-    vcpkg_check_features(
-        OUT_FEATURE_OPTIONS CLANG_FEATURE_OPTIONS
-        FEATURES
-            clang-enable-cir CLANG_ENABLE_CIR
-            clang-enable-static-analyzer CLANG_ENABLE_STATIC_ANALYZER
-    )
-    string(REGEX MATCH "^[0-9]+" CLANG_VERSION_MAJOR ${VERSION})
-    list(APPEND CLANG_FEATURE_OPTIONS
-        -DCLANG_INSTALL_PACKAGE_DIR:PATH=share/clang
-        -DCLANG_TOOLS_INSTALL_DIR:PATH=tools/llvm
-        # 1) LLVM/Clang tools are relocated from ./bin/ to ./tools/llvm/ (CLANG_TOOLS_INSTALL_DIR=tools/llvm)
-        # 2) Clang resource files should be relocated from lib/clang/<major_version> to ../tools/llvm/lib/clang/<major_version>
-        -DCLANG_RESOURCE_DIR=lib/clang/${CLANG_VERSION_MAJOR}
-    )
+  list(APPEND LLVM_ENABLE_PROJECTS "clang")
+  vcpkg_check_features(OUT_FEATURE_OPTIONS
+                       CLANG_FEATURE_OPTIONS
+                       FEATURES
+                       clang-enable-cir
+                       CLANG_ENABLE_CIR
+                       clang-enable-static-analyzer
+                       CLANG_ENABLE_STATIC_ANALYZER)
+  string(REGEX MATCH "^[0-9]+" CLANG_VERSION_MAJOR ${VERSION})
+  list(APPEND
+       CLANG_FEATURE_OPTIONS
+       -DCLANG_INSTALL_PACKAGE_DIR:PATH=share/clang
+       -DCLANG_TOOLS_INSTALL_DIR:PATH=tools/llvm
+       # 1) LLVM/Clang tools are relocated from ./bin/ to ./tools/llvm/ (CLANG_TOOLS_INSTALL_DIR=tools/llvm)
+       # 2) Clang resource files should be relocated from lib/clang/<major_version> to ../tools/llvm/lib/clang/<major_version>
+       -DCLANG_RESOURCE_DIR=lib/clang/${CLANG_VERSION_MAJOR})
 endif()
 if("clang-tools-extra" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "clang-tools-extra")
+  list(APPEND LLVM_ENABLE_PROJECTS "clang-tools-extra")
 endif()
 if("flang" IN_LIST FEATURES)
-    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
-        message(FATAL_ERROR "Building Flang with MSVC is not supported on x86. Disable it until issues are fixed.")
-    endif()
-    list(APPEND LLVM_ENABLE_PROJECTS "flang")
-    list(APPEND FEATURE_OPTIONS
-        -DFLANG_INSTALL_PACKAGE_DIR:PATH=share/flang
-        -DFLANG_TOOLS_INSTALL_DIR:PATH=tools/llvm
+  if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_TARGET_ARCHITECTURE
+                                                              STREQUAL "x86")
+    message(FATAL_ERROR "Building Flang with MSVC is not supported on x86. Disable it until issues are fixed."
     )
-    list(APPEND FEATURE_OPTIONS
-        # Flang requires C++17
-        -DCMAKE_CXX_STANDARD=17
-    )
+  endif()
+  list(APPEND LLVM_ENABLE_PROJECTS "flang")
+  list(APPEND FEATURE_OPTIONS -DFLANG_INSTALL_PACKAGE_DIR:PATH=share/flang
+       -DFLANG_TOOLS_INSTALL_DIR:PATH=tools/llvm)
+  list(APPEND FEATURE_OPTIONS
+       # Flang requires C++17
+       -DCMAKE_CXX_STANDARD=17)
 endif()
 if("lld" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "lld")
-    list(APPEND FEATURE_OPTIONS
-        -DLLD_INSTALL_PACKAGE_DIR:PATH=share/lld
-        -DLLD_TOOLS_INSTALL_DIR:PATH=tools/llvm
-    )
+  list(APPEND LLVM_ENABLE_PROJECTS "lld")
+  list(APPEND FEATURE_OPTIONS -DLLD_INSTALL_PACKAGE_DIR:PATH=share/lld
+       -DLLD_TOOLS_INSTALL_DIR:PATH=tools/llvm)
 endif()
 if("lldb" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "lldb")
-    list(APPEND FEATURE_OPTIONS
-        -DLLDB_ENABLE_CURSES=OFF
-    )
+  list(APPEND LLVM_ENABLE_PROJECTS "lldb")
+  list(APPEND FEATURE_OPTIONS -DLLDB_ENABLE_CURSES=OFF)
 endif()
 if("mlir" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "mlir")
-    list(APPEND FEATURE_OPTIONS
-        -DMLIR_INSTALL_PACKAGE_DIR:PATH=share/mlir
-        -DMLIR_TOOLS_INSTALL_DIR:PATH=tools/llvm
-        -DMLIR_INSTALL_AGGREGATE_OBJECTS=OFF # Disables installation of object files in lib/objects-{CMAKE_BUILD_TYPE}.
-    )
-    if("enable-mlir-python-bindings" IN_LIST FEATURES)
-        list(APPEND FEATURE_OPTIONS
-            -DMLIR_ENABLE_BINDINGS_PYTHON=ON
-            "-Dpybind11_DIR=${CURRENT_INSTALLED_DIR}/share/pybind11"
-        )
-    endif()
+  list(APPEND LLVM_ENABLE_PROJECTS "mlir")
+  list(APPEND
+       FEATURE_OPTIONS
+       -DMLIR_INSTALL_PACKAGE_DIR:PATH=share/mlir
+       -DMLIR_TOOLS_INSTALL_DIR:PATH=tools/llvm
+       -DMLIR_INSTALL_AGGREGATE_OBJECTS=OFF # Disables installation of object files in lib/objects-{CMAKE_BUILD_TYPE}.
+  )
+  if("enable-mlir-python-bindings" IN_LIST FEATURES)
+    list(APPEND FEATURE_OPTIONS -DMLIR_ENABLE_BINDINGS_PYTHON=ON
+         "-Dpybind11_DIR=${CURRENT_INSTALLED_DIR}/share/pybind11")
+  endif()
 endif()
 if("polly" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_PROJECTS "polly")
-    list(APPEND FEATURE_OPTIONS
-        -DPOLLY_INSTALL_PACKAGE_DIR:PATH=share/polly
-    )
+  list(APPEND LLVM_ENABLE_PROJECTS "polly")
+  list(APPEND FEATURE_OPTIONS -DPOLLY_INSTALL_PACKAGE_DIR:PATH=share/polly)
 endif()
 
 # Supported runtimes: libc;libclc;libcxx;libcxxabi;libunwind;compiler-rt;openmp;llvm-libgcc;offload;flang-rt
 set(LLVM_ENABLE_RUNTIMES)
 if("libc" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "libc")
+  list(APPEND LLVM_ENABLE_RUNTIMES "libc")
 endif()
 if("libclc" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "libclc")
+  list(APPEND LLVM_ENABLE_RUNTIMES "libclc")
 endif()
 if("libcxx" IN_LIST FEATURES)
-    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_DETECTED_MSVC_VERSION LESS "1914")
-        # libcxx supports being built with clang-cl, but not with MSVC’s cl.exe, as cl doesn’t support the #include_next extension.
-        # Furthermore, VS 2017 or newer (19.14) is required.
-        # More info: https://releases.llvm.org/17.0.1/projects/libcxx/docs/BuildingLibcxx.html#support-for-windows
-        message(FATAL_ERROR "libcxx requiries MSVC 19.14 or newer.")
-    endif()
-    list(APPEND LLVM_ENABLE_RUNTIMES "libcxx")
+  if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_DETECTED_MSVC_VERSION
+                                                              LESS "1914")
+    # libcxx supports being built with clang-cl, but not with MSVC’s cl.exe, as cl doesn’t support the #include_next extension.
+    # Furthermore, VS 2017 or newer (19.14) is required.
+    # More info: https://releases.llvm.org/17.0.1/projects/libcxx/docs/BuildingLibcxx.html#support-for-windows
+    message(FATAL_ERROR "libcxx requiries MSVC 19.14 or newer.")
+  endif()
+  list(APPEND LLVM_ENABLE_RUNTIMES "libcxx")
 endif()
 if("libcxxabi" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "libcxxabi")
+  list(APPEND LLVM_ENABLE_RUNTIMES "libcxxabi")
 endif()
 if("libunwind" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "libunwind")
+  list(APPEND LLVM_ENABLE_RUNTIMES "libunwind")
 endif()
 if("compiler-rt" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "compiler-rt")
-    vcpkg_check_features(
-        OUT_FEATURE_OPTIONS COMPILER_RT_FEATURE_OPTIONS
-        FEATURES
-            enable-ios COMPILER_RT_ENABLE_IOS
-    )
+  list(APPEND LLVM_ENABLE_RUNTIMES "compiler-rt")
+  vcpkg_check_features(OUT_FEATURE_OPTIONS
+                       COMPILER_RT_FEATURE_OPTIONS
+                       FEATURES
+                       enable-ios
+                       COMPILER_RT_ENABLE_IOS)
 endif()
 if("openmp" IN_LIST FEATURES)
-    list(APPEND LLVM_ENABLE_RUNTIMES "openmp")
+  list(APPEND LLVM_ENABLE_RUNTIMES "openmp")
 endif()
 
 # this is for normal targets
@@ -228,15 +221,14 @@ set(known_llvm_targets
     VE
     WebAssembly
     X86
-    XCore
-)
+    XCore)
 
 set(LLVM_TARGETS_TO_BUILD)
 foreach(llvm_target IN LISTS known_llvm_targets)
-    string(TOLOWER "target-${llvm_target}" feature_name)
-    if(feature_name IN_LIST FEATURES)
-        list(APPEND LLVM_TARGETS_TO_BUILD "${llvm_target}")
-    endif()
+  string(TOLOWER "target-${llvm_target}" feature_name)
+  if(feature_name IN_LIST FEATURES)
+    list(APPEND LLVM_TARGETS_TO_BUILD "${llvm_target}")
+  endif()
 endforeach()
 
 # this is for experimental targets
@@ -245,15 +237,14 @@ set(known_llvm_experimental_targets
     CSKY
     DirectX
     M68k
-    Xtensa
-)
+    Xtensa)
 
 set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD)
 foreach(llvm_target IN LISTS known_llvm_experimental_targets)
-    string(TOLOWER "target-${llvm_target}" feature_name)
-    if(feature_name IN_LIST FEATURES)
-        list(APPEND LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "${llvm_target}")
-    endif()
+  string(TOLOWER "target-${llvm_target}" feature_name)
+  if(feature_name IN_LIST FEATURES)
+    list(APPEND LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "${llvm_target}")
+  endif()
 endforeach()
 
 vcpkg_find_acquire_program(PYTHON3)
@@ -263,65 +254,72 @@ vcpkg_add_to_path(PREPEND "${PYTHON3_DIR}")
 file(REMOVE "${SOURCE_PATH}/llvm/cmake/modules/Findzstd.cmake")
 
 if("${LLVM_ENABLE_RUNTIMES}" STREQUAL "")
-    list(APPEND FEATURE_OPTIONS
-        -DLLVM_INCLUDE_RUNTIMES=OFF
-        -DLLVM_BUILD_RUNTIMES=OFF
-        -DLLVM_BUILD_RUNTIME=OFF
-    )
+  list(APPEND
+       FEATURE_OPTIONS
+       -DLLVM_INCLUDE_RUNTIMES=OFF
+       -DLLVM_BUILD_RUNTIMES=OFF
+       -DLLVM_BUILD_RUNTIME=OFF)
 endif()
 
 # At least one target must be specified, otherwise default to "all".
 if("${LLVM_TARGETS_TO_BUILD}" STREQUAL "")
-    set(LLVM_TARGETS_TO_BUILD "all")
+  set(LLVM_TARGETS_TO_BUILD "all")
 endif()
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}/llvm"
-    OPTIONS
-        -DLLVM_INCLUDE_EXAMPLES=OFF
-        -DLLVM_BUILD_EXAMPLES=OFF
-        -DLLVM_INCLUDE_TESTS=OFF
-        -DLLVM_BUILD_TESTS=OFF
-        -DLLVM_INCLUDE_BENCHMARKS=OFF
-        -DLLVM_BUILD_BENCHMARKS=OFF
-        # Force TableGen to be built with optimization. This will significantly improve build time.
-        -DLLVM_OPTIMIZED_TABLEGEN=ON
-        -DPACKAGE_VERSION=${VERSION}
-        # Limit the maximum number of concurrent link jobs to 1. This should fix low amount of memory issue for link.
-        -DLLVM_PARALLEL_LINK_JOBS=1
-        -DLLVM_INSTALL_PACKAGE_DIR:PATH=share/llvm
-        -DLLVM_TOOLS_INSTALL_DIR:PATH=tools/llvm
-        "-DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS}"
-        "-DLLVM_ENABLE_RUNTIMES=${LLVM_ENABLE_RUNTIMES}"
-        "-DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD}"
-        "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}"
-        ${FEATURE_OPTIONS}
-        ${CLANG_FEATURE_OPTIONS}
-        ${COMPILER_RT_FEATURE_OPTIONS}
-)
+vcpkg_cmake_configure(SOURCE_PATH
+                      "${SOURCE_PATH}/llvm"
+                      OPTIONS
+                      -DLLVM_INCLUDE_EXAMPLES=OFF
+                      -DLLVM_BUILD_EXAMPLES=OFF
+                      -DLLVM_INCLUDE_TESTS=OFF
+                      -DLLVM_BUILD_TESTS=OFF
+                      -DLLVM_INCLUDE_BENCHMARKS=OFF
+                      -DLLVM_BUILD_BENCHMARKS=OFF
+                      # Force TableGen to be built with optimization. This will significantly improve build time.
+                      -DLLVM_OPTIMIZED_TABLEGEN=ON
+                      -DPACKAGE_VERSION=${VERSION}
+                      # Limit the maximum number of concurrent link jobs to 1. This should fix low amount of memory issue for link.
+                      -DLLVM_PARALLEL_LINK_JOBS=1
+                      -DLLVM_INSTALL_PACKAGE_DIR:PATH=share/llvm
+                      -DLLVM_TOOLS_INSTALL_DIR:PATH=tools/llvm
+                      "-DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS}"
+                      "-DLLVM_ENABLE_RUNTIMES=${LLVM_ENABLE_RUNTIMES}"
+                      "-DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD}"
+                      "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}"
+                      ${FEATURE_OPTIONS}
+                      ${CLANG_FEATURE_OPTIONS}
+                      ${COMPILER_RT_FEATURE_OPTIONS})
 
 vcpkg_cmake_install(ADD_BIN_TO_PATH)
 
 function(llvm_cmake_package_config_fixup package_name)
-    cmake_parse_arguments("arg" "DO_NOT_DELETE_PARENT_CONFIG_PATH" "FEATURE_NAME;CONFIG_PATH" "" ${ARGN})
-    if(NOT DEFINED arg_FEATURE_NAME)
-        set(arg_FEATURE_NAME ${package_name})
+  cmake_parse_arguments("arg"
+                        "DO_NOT_DELETE_PARENT_CONFIG_PATH"
+                        "FEATURE_NAME;CONFIG_PATH"
+                        ""
+                        ${ARGN})
+  if(NOT DEFINED arg_FEATURE_NAME)
+    set(arg_FEATURE_NAME ${package_name})
+  endif()
+  if("${arg_FEATURE_NAME}" STREQUAL "${PORT}" OR "${arg_FEATURE_NAME}" IN_LIST FEATURES)
+    set(args)
+    list(APPEND args PACKAGE_NAME "${package_name}")
+    if(arg_DO_NOT_DELETE_PARENT_CONFIG_PATH)
+      list(APPEND args "DO_NOT_DELETE_PARENT_CONFIG_PATH")
     endif()
-    if("${arg_FEATURE_NAME}" STREQUAL "${PORT}" OR "${arg_FEATURE_NAME}" IN_LIST FEATURES)
-        set(args)
-        list(APPEND args PACKAGE_NAME "${package_name}")
-        if(arg_DO_NOT_DELETE_PARENT_CONFIG_PATH)
-            list(APPEND args "DO_NOT_DELETE_PARENT_CONFIG_PATH")
-        endif()
-        if(arg_CONFIG_PATH)
-            list(APPEND args "CONFIG_PATH" "${arg_CONFIG_PATH}")
-        endif()
-        vcpkg_cmake_config_fixup(${args})
-        file(INSTALL "${SOURCE_PATH}/${arg_FEATURE_NAME}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}" RENAME copyright)
-        if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage")
-            file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}" RENAME usage)
-        endif()
+    if(arg_CONFIG_PATH)
+      list(APPEND args "CONFIG_PATH" "${arg_CONFIG_PATH}")
     endif()
+    vcpkg_cmake_config_fixup(${args})
+    file(INSTALL "${SOURCE_PATH}/${arg_FEATURE_NAME}/LICENSE.TXT"
+         DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}"
+         RENAME copyright)
+    if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage")
+      file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage"
+           DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}"
+           RENAME usage)
+    endif()
+  endif()
 endfunction()
 
 llvm_cmake_package_config_fixup("clang" DO_NOT_DELETE_PARENT_CONFIG_PATH)
@@ -332,10 +330,12 @@ llvm_cmake_package_config_fixup("polly" DO_NOT_DELETE_PARENT_CONFIG_PATH)
 llvm_cmake_package_config_fixup("llvm")
 
 if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig" "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/debug/share/pkgconfig"
+       "${CURRENT_PACKAGES_DIR}/debug/lib/pkgconfig")
 endif()
 if(EXISTS "${CURRENT_PACKAGES_DIR}/share/pkgconfig")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig" "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/share/pkgconfig"
+       "${CURRENT_PACKAGES_DIR}/lib/pkgconfig")
 endif()
 vcpkg_fixup_pkgconfig()
 
@@ -343,27 +343,24 @@ vcpkg_copy_tool_dependencies("${CURRENT_PACKAGES_DIR}/tools/${PORT}")
 
 # Move Clang's runtime libraries from bin/lib to tools/${PORT}/lib
 if(EXISTS "${CURRENT_PACKAGES_DIR}/bin/lib")
-    file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
-    file(RENAME "${CURRENT_PACKAGES_DIR}/bin/lib" "${CURRENT_PACKAGES_DIR}/tools/${PORT}/lib")
+  file(MAKE_DIRECTORY "${CURRENT_PACKAGES_DIR}/tools/${PORT}")
+  file(RENAME "${CURRENT_PACKAGES_DIR}/bin/lib"
+       "${CURRENT_PACKAGES_DIR}/tools/${PORT}/lib")
 endif()
 if(EXISTS "${CURRENT_PACKAGES_DIR}/debug/bin/lib")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/lib")
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/bin/lib")
 endif()
 
 # Remove debug headers and tools
 if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
-        "${CURRENT_PACKAGES_DIR}/debug/share"
-        "${CURRENT_PACKAGES_DIR}/debug/tools"
-    )
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+       "${CURRENT_PACKAGES_DIR}/debug/share" "${CURRENT_PACKAGES_DIR}/debug/tools")
 endif()
 
 # LLVM generates shared libraries in a static build (LLVM-C.dll, libclang.dll, LTO.dll, Remarks.dll, ...)
 # for the corresponding export targets (used in LLVMExports-<config>.cmake files on the Windows platform)
 if(VCPKG_TARGET_IS_WINDOWS)
-    set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
+  set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)
 else()
-    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin"
-        "${CURRENT_PACKAGES_DIR}/debug/bin"
-    )
+  file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/bin" "${CURRENT_PACKAGES_DIR}/debug/bin")
 endif()

--- a/ci/vcpkg/overlay/symengine/portfile.cmake
+++ b/ci/vcpkg/overlay/symengine/portfile.cmake
@@ -1,50 +1,58 @@
-vcpkg_from_github(
-    OUT_SOURCE_PATH SOURCE_PATH
-    REPO symengine/symengine
-    REF "v${VERSION}"
-    SHA512 2b6012ed65064ff81c8828032c5a3148340582274e3604db2a43797ddbaa191520ed97da41efc2e842ba4a25326f53becc51f1e98935e8c34625bc5eaac8397f
-    HEAD_REF master
-)
+vcpkg_from_github(OUT_SOURCE_PATH
+                  SOURCE_PATH
+                  REPO
+                  symengine/symengine
+                  REF
+                  "v${VERSION}"
+                  SHA512
+                  2b6012ed65064ff81c8828032c5a3148340582274e3604db2a43797ddbaa191520ed97da41efc2e842ba4a25326f53becc51f1e98935e8c34625bc5eaac8397f
+                  HEAD_REF
+                  master)
 
-vcpkg_check_features(
-    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
-    FEATURES
-        arb WITH_ARB
-        flint WITH_FLINT 
-        mpfr WITH_MPFR
-        tcmalloc WITH_TCMALLOC
-        llvm WITH_LLVM
-)
+vcpkg_check_features(OUT_FEATURE_OPTIONS
+                     FEATURE_OPTIONS
+                     FEATURES
+                     arb
+                     WITH_ARB
+                     flint
+                     WITH_FLINT
+                     mpfr
+                     WITH_MPFR
+                     tcmalloc
+                     WITH_TCMALLOC
+                     llvm
+                     WITH_LLVM)
 
 if(integer-class-flint IN_LIST FEATURES)
-    set(INTEGER_CLASS flint)
+  set(INTEGER_CLASS flint)
 endif()
 
 if(VCPKG_TARGET_IS_UWP)
-    set(VCPKG_C_FLAGS "${VCPKG_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE")
-    set(VCPKG_CXX_FLAGS "${VCPKG_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE")
+  set(VCPKG_C_FLAGS
+      "${VCPKG_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE")
+  set(VCPKG_CXX_FLAGS
+      "${VCPKG_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_DEPRECATE")
 endif()
 
-vcpkg_cmake_configure(
-    SOURCE_PATH "${SOURCE_PATH}"
-    OPTIONS
-        -DINTEGER_CLASS=${INTEGER_CLASS}
-        -DBUILD_BENCHMARKS=no
-        -DBUILD_TESTS=no
-        -DMSVC_WARNING_LEVEL=3
-        -DMSVC_USE_MT=no
-        -DWITH_SYMENGINE_RCP=yes
-        -DWITH_SYMENGINE_TEUCHOS=no
-        -DWITH_SYMENGINE_THREAD_SAFE=yes
-        ${FEATURE_OPTIONS}
-)
+vcpkg_cmake_configure(SOURCE_PATH
+                      "${SOURCE_PATH}"
+                      OPTIONS
+                      -DINTEGER_CLASS=${INTEGER_CLASS}
+                      -DBUILD_BENCHMARKS=no
+                      -DBUILD_TESTS=no
+                      -DMSVC_WARNING_LEVEL=3
+                      -DMSVC_USE_MT=no
+                      -DWITH_SYMENGINE_RCP=yes
+                      -DWITH_SYMENGINE_TEUCHOS=no
+                      -DWITH_SYMENGINE_THREAD_SAFE=yes
+                      ${FEATURE_OPTIONS})
 
 vcpkg_cmake_install()
 
 if(EXISTS "${CURRENT_PACKAGES_DIR}/CMake")
-    vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
+  vcpkg_cmake_config_fixup(CONFIG_PATH CMake)
 elseif(EXISTS "${CURRENT_PACKAGES_DIR}/lib/cmake/${PORT}")
-    vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
+  vcpkg_cmake_config_fixup(CONFIG_PATH lib/cmake/${PORT})
 endif()
 
 vcpkg_copy_pdbs()
@@ -52,11 +60,10 @@ vcpkg_copy_pdbs()
 file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
 file(REMOVE "${CURRENT_PACKAGES_DIR}/include/symengine/symengine_config_cling.h")
 
-vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/symengine/SymEngineConfig.cmake" "${CURRENT_BUILDTREES_DIR}" "") # not used, inside if (False)
 vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/symengine/SymEngineConfig.cmake"
-    [[${SYMENGINE_CMAKE_DIR}/../../../include]]
-    [[${SYMENGINE_CMAKE_DIR}/../../include]]
-    IGNORE_UNCHANGED
-)
+                     "${CURRENT_BUILDTREES_DIR}" "") # not used, inside if (False)
+vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/symengine/SymEngineConfig.cmake"
+                     [[${SYMENGINE_CMAKE_DIR}/../../../include]]
+                     [[${SYMENGINE_CMAKE_DIR}/../../include]] IGNORE_UNCHANGED)
 
 vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/cpp/src/arrow/util/benchmark_util.h
+++ b/cpp/src/arrow/util/benchmark_util.h
@@ -36,13 +36,29 @@ template <typename Func>
 struct BenchmarkArgsType;
 
 // Pattern matching that extracts the vector element type of Benchmark::Args()
+// benchmark::internal::Benchmark was deprecated in newer Google Benchmark in favor
+// of benchmark::Benchmark, but both names refer to the same class. Suppress the
+// deprecation warning to stay compatible with both old and new benchmark versions.
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#endif
 template <typename Values>
-struct BenchmarkArgsType<benchmark::Benchmark* (
-    benchmark::Benchmark::*)(const std::vector<Values>&)> {
+struct BenchmarkArgsType<benchmark::internal::Benchmark* (
+    benchmark::internal::Benchmark::*)(const std::vector<Values>&)> {
   using type = Values;
 };
 
-using ArgsType = typename BenchmarkArgsType<decltype(&benchmark::Benchmark::Args)>::type;
+using ArgsType =
+    typename BenchmarkArgsType<decltype(&benchmark::internal::Benchmark::Args)>::type;
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 using internal::CpuInfo;
 
@@ -83,7 +99,14 @@ struct GenericItemsArgs {
   benchmark::State& state_;
 };
 
-void BenchmarkSetArgsWithSizes(benchmark::Benchmark* bench,
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#endif
+void BenchmarkSetArgsWithSizes(benchmark::internal::Benchmark* bench,
                                const std::vector<int64_t>& sizes = kMemorySizes) {
   bench->Unit(benchmark::kMicrosecond);
 
@@ -94,15 +117,20 @@ void BenchmarkSetArgsWithSizes(benchmark::Benchmark* bench,
   }
 }
 
-void BenchmarkSetArgs(benchmark::Benchmark* bench) {
+void BenchmarkSetArgs(benchmark::internal::Benchmark* bench) {
   BenchmarkSetArgsWithSizes(bench, kMemorySizes);
 }
 
-void RegressionSetArgs(benchmark::Benchmark* bench) {
+void RegressionSetArgs(benchmark::internal::Benchmark* bench) {
   // Regression do not need to account for cache hierarchy, thus optimize for
   // the best case.
   BenchmarkSetArgsWithSizes(bench, {kL1Size});
 }
+#if defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#elif defined(_MSC_VER)
+#  pragma warning(pop)
+#endif
 
 // RAII struct to handle some of the boilerplate in regression benchmarks
 struct RegressionArgs {

--- a/cpp/src/arrow/util/benchmark_util.h
+++ b/cpp/src/arrow/util/benchmark_util.h
@@ -37,13 +37,12 @@ struct BenchmarkArgsType;
 
 // Pattern matching that extracts the vector element type of Benchmark::Args()
 template <typename Values>
-struct BenchmarkArgsType<benchmark::internal::Benchmark* (
-    benchmark::internal::Benchmark::*)(const std::vector<Values>&)> {
+struct BenchmarkArgsType<benchmark::Benchmark* (
+    benchmark::Benchmark::*)(const std::vector<Values>&)> {
   using type = Values;
 };
 
-using ArgsType =
-    typename BenchmarkArgsType<decltype(&benchmark::internal::Benchmark::Args)>::type;
+using ArgsType = typename BenchmarkArgsType<decltype(&benchmark::Benchmark::Args)>::type;
 
 using internal::CpuInfo;
 
@@ -84,7 +83,7 @@ struct GenericItemsArgs {
   benchmark::State& state_;
 };
 
-void BenchmarkSetArgsWithSizes(benchmark::internal::Benchmark* bench,
+void BenchmarkSetArgsWithSizes(benchmark::Benchmark* bench,
                                const std::vector<int64_t>& sizes = kMemorySizes) {
   bench->Unit(benchmark::kMicrosecond);
 
@@ -95,11 +94,11 @@ void BenchmarkSetArgsWithSizes(benchmark::internal::Benchmark* bench,
   }
 }
 
-void BenchmarkSetArgs(benchmark::internal::Benchmark* bench) {
+void BenchmarkSetArgs(benchmark::Benchmark* bench) {
   BenchmarkSetArgsWithSizes(bench, kMemorySizes);
 }
 
-void RegressionSetArgs(benchmark::internal::Benchmark* bench) {
+void RegressionSetArgs(benchmark::Benchmark* bench) {
   // Regression do not need to account for cache hierarchy, thus optimize for
   // the best case.
   BenchmarkSetArgsWithSizes(bench, {kL1Size});

--- a/cpp/src/arrow/util/ree_util.h
+++ b/cpp/src/arrow/util/ree_util.h
@@ -392,14 +392,14 @@ class RunEndEncodedArraySpan {
   /// \warning Avoid calling end() in a loop, as it will recompute the physical
   /// length of the array on each call (O(log N) cost per call).
   ///
-  /// \par You can write your loops like this instead:
+  /// You can write your loops like this instead:
   /// \code
   /// for (auto it = array.begin(), end = array.end(); it != end; ++it) {
   ///   // ...
   /// }
   /// \endcode
   ///
-  /// \par Or this version that does not look like idiomatic C++, but removes
+  /// Or this version that does not look like idiomatic C++, but removes
   /// the need for calling end() completely:
   /// \code
   /// for (auto it = array.begin(); !it.is_end(array); ++it) {

--- a/cpp/src/gandiva/encrypt_mode_dispatcher.cc
+++ b/cpp/src/gandiva/encrypt_mode_dispatcher.cc
@@ -16,23 +16,21 @@
 // under the License.
 
 #include "gandiva/encrypt_mode_dispatcher.h"
-#include "gandiva/encrypt_utils_ecb.h"
-#include "gandiva/encrypt_utils_cbc.h"
-#include "gandiva/encrypt_utils_gcm.h"
-#include "arrow/util/string.h"
-#include <string>
 #include <sstream>
 #include <stdexcept>
+#include <string>
 #include <vector>
+#include "arrow/util/string.h"
+#include "gandiva/encrypt_utils_cbc.h"
+#include "gandiva/encrypt_utils_ecb.h"
+#include "gandiva/encrypt_utils_gcm.h"
 
 namespace gandiva {
 
 // Supported encryption modes
 static const std::vector<std::string_view> SUPPORTED_MODES = {
-    AES_ECB_MODE, AES_ECB_PKCS7_MODE, AES_ECB_NONE_MODE,
-    AES_CBC_MODE, AES_CBC_PKCS7_MODE, AES_CBC_NONE_MODE,
-    AES_GCM_MODE
-};
+    AES_ECB_MODE,       AES_ECB_PKCS7_MODE, AES_ECB_NONE_MODE, AES_CBC_MODE,
+    AES_CBC_PKCS7_MODE, AES_CBC_NONE_MODE,  AES_GCM_MODE};
 
 enum class EncryptionMode {
   ECB,
@@ -56,13 +54,13 @@ EncryptionMode ParseEncryptionMode(std::string_view mode_str) {
   return EncryptionMode::UNKNOWN;
 }
 
-int32_t EncryptModeDispatcher::encrypt(
-    const char* plaintext, int32_t plaintext_len, const char* key,
-    int32_t key_len, const char* mode, int32_t mode_len, const char* iv,
-    int32_t iv_len, const char* fifth_argument, int32_t fifth_argument_len,
-    unsigned char* cipher) {
-  std::string mode_str =
-      arrow::internal::AsciiToUpper(std::string_view(mode, mode_len));
+int32_t EncryptModeDispatcher::encrypt(const char* plaintext, int32_t plaintext_len,
+                                       const char* key, int32_t key_len, const char* mode,
+                                       int32_t mode_len, const char* iv, int32_t iv_len,
+                                       const char* fifth_argument,
+                                       int32_t fifth_argument_len,
+                                       unsigned char* cipher) {
+  std::string mode_str = arrow::internal::AsciiToUpper(std::string_view(mode, mode_len));
 
   switch (ParseEncryptionMode(mode_str)) {
     case EncryptionMode::ECB:
@@ -75,15 +73,15 @@ int32_t EncryptModeDispatcher::encrypt(
     case EncryptionMode::CBC:
     case EncryptionMode::CBC_PKCS7:
       // Shorthand AES-CBC and explicit AES-CBC-PKCS7 both use CBC with PKCS7
-      return aes_encrypt_cbc(plaintext, plaintext_len, key, key_len,
-                             iv, iv_len, true, cipher);
+      return aes_encrypt_cbc(plaintext, plaintext_len, key, key_len, iv, iv_len, true,
+                             cipher);
     case EncryptionMode::CBC_NONE:
       // CBC without padding
-      return aes_encrypt_cbc(plaintext, plaintext_len, key, key_len,
-                             iv, iv_len, false, cipher);
+      return aes_encrypt_cbc(plaintext, plaintext_len, key, key_len, iv, iv_len, false,
+                             cipher);
     case EncryptionMode::GCM:
-      return aes_encrypt_gcm(plaintext, plaintext_len, key, key_len,
-                             iv, iv_len, fifth_argument, fifth_argument_len, cipher);
+      return aes_encrypt_gcm(plaintext, plaintext_len, key, key_len, iv, iv_len,
+                             fifth_argument, fifth_argument_len, cipher);
     case EncryptionMode::UNKNOWN:
     default: {
       std::string modes_str = arrow::internal::JoinStrings(SUPPORTED_MODES, ", ");
@@ -95,13 +93,13 @@ int32_t EncryptModeDispatcher::encrypt(
   }
 }
 
-int32_t EncryptModeDispatcher::decrypt(
-    const char* ciphertext, int32_t ciphertext_len, const char* key,
-    int32_t key_len, const char* mode, int32_t mode_len, const char* iv,
-    int32_t iv_len, const char* fifth_argument, int32_t fifth_argument_len,
-    unsigned char* plaintext) {
-  std::string mode_str =
-      arrow::internal::AsciiToUpper(std::string_view(mode, mode_len));
+int32_t EncryptModeDispatcher::decrypt(const char* ciphertext, int32_t ciphertext_len,
+                                       const char* key, int32_t key_len, const char* mode,
+                                       int32_t mode_len, const char* iv, int32_t iv_len,
+                                       const char* fifth_argument,
+                                       int32_t fifth_argument_len,
+                                       unsigned char* plaintext) {
+  std::string mode_str = arrow::internal::AsciiToUpper(std::string_view(mode, mode_len));
 
   switch (ParseEncryptionMode(mode_str)) {
     case EncryptionMode::ECB:
@@ -114,15 +112,15 @@ int32_t EncryptModeDispatcher::decrypt(
     case EncryptionMode::CBC:
     case EncryptionMode::CBC_PKCS7:
       // Shorthand AES-CBC and explicit AES-CBC-PKCS7 both use CBC with PKCS7
-      return aes_decrypt_cbc(ciphertext, ciphertext_len, key, key_len,
-                             iv, iv_len, true, plaintext);
+      return aes_decrypt_cbc(ciphertext, ciphertext_len, key, key_len, iv, iv_len, true,
+                             plaintext);
     case EncryptionMode::CBC_NONE:
       // CBC without padding
-      return aes_decrypt_cbc(ciphertext, ciphertext_len, key, key_len,
-                             iv, iv_len, false, plaintext);
+      return aes_decrypt_cbc(ciphertext, ciphertext_len, key, key_len, iv, iv_len, false,
+                             plaintext);
     case EncryptionMode::GCM:
-      return aes_decrypt_gcm(ciphertext, ciphertext_len, key, key_len,
-                             iv, iv_len, fifth_argument, fifth_argument_len, plaintext);
+      return aes_decrypt_gcm(ciphertext, ciphertext_len, key, key_len, iv, iv_len,
+                             fifth_argument, fifth_argument_len, plaintext);
     case EncryptionMode::UNKNOWN:
     default: {
       std::string modes_str = arrow::internal::JoinStrings(SUPPORTED_MODES, ", ");
@@ -135,4 +133,3 @@ int32_t EncryptModeDispatcher::decrypt(
 }
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_mode_dispatcher.h
+++ b/cpp/src/gandiva/encrypt_mode_dispatcher.h
@@ -45,12 +45,10 @@ class EncryptModeDispatcher {
    * @return Length of encrypted data in bytes
    * @throws std::runtime_error on encryption failure or unsupported mode
    */
-  static int32_t encrypt(const char* plaintext, int32_t plaintext_len,
-                         const char* key, int32_t key_len,
-                         const char* mode, int32_t mode_len,
-                         const char* iv, int32_t iv_len,
-                         const char* fifth_argument, int32_t fifth_argument_len,
-                         unsigned char* cipher);
+  static int32_t encrypt(const char* plaintext, int32_t plaintext_len, const char* key,
+                         int32_t key_len, const char* mode, int32_t mode_len,
+                         const char* iv, int32_t iv_len, const char* fifth_argument,
+                         int32_t fifth_argument_len, unsigned char* cipher);
 
   /**
    * Decrypt data using the specified mode
@@ -69,15 +67,12 @@ class EncryptModeDispatcher {
    * @return Length of decrypted data in bytes
    * @throws std::runtime_error on decryption failure or unsupported mode
    */
-  static int32_t decrypt(const char* ciphertext, int32_t ciphertext_len,
-                         const char* key, int32_t key_len,
-                         const char* mode, int32_t mode_len,
-                         const char* iv, int32_t iv_len,
-                         const char* fifth_argument, int32_t fifth_argument_len,
-                         unsigned char* plaintext);
+  static int32_t decrypt(const char* ciphertext, int32_t ciphertext_len, const char* key,
+                         int32_t key_len, const char* mode, int32_t mode_len,
+                         const char* iv, int32_t iv_len, const char* fifth_argument,
+                         int32_t fifth_argument_len, unsigned char* plaintext);
 };
 
 }  // namespace gandiva
 
 #endif  // GANDIVA_ENCRYPT_MODE_DISPATCHER_H
-

--- a/cpp/src/gandiva/encrypt_utils_cbc.cc
+++ b/cpp/src/gandiva/encrypt_utils_cbc.cc
@@ -16,13 +16,13 @@
 // under the License.
 
 #include "gandiva/encrypt_utils_cbc.h"
-#include "gandiva/encrypt_utils_common.h"
 #include <openssl/aes.h>
 #include <openssl/err.h>
-#include <stdexcept>
+#include <cctype>
 #include <cstring>
 #include <sstream>
-#include <cctype>
+#include <stdexcept>
+#include "gandiva/encrypt_utils_common.h"
 
 namespace gandiva {
 
@@ -49,8 +49,8 @@ const EVP_CIPHER* get_cbc_cipher_algo(int32_t key_length) {
 
 GANDIVA_EXPORT
 int32_t aes_encrypt_cbc(const char* plaintext, int32_t plaintext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        bool use_padding, unsigned char* cipher) {
+                        int32_t key_len, const char* iv, int32_t iv_len, bool use_padding,
+                        unsigned char* cipher) {
   // Validate IV length
   if (iv_len != 16) {
     std::ostringstream oss;
@@ -108,8 +108,8 @@ int32_t aes_encrypt_cbc(const char* plaintext, int32_t plaintext_len, const char
 
 GANDIVA_EXPORT
 int32_t aes_decrypt_cbc(const char* ciphertext, int32_t ciphertext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        bool use_padding, unsigned char* plaintext) {
+                        int32_t key_len, const char* iv, int32_t iv_len, bool use_padding,
+                        unsigned char* plaintext) {
   // Validate IV length
   if (iv_len != 16) {
     std::ostringstream oss;
@@ -166,4 +166,3 @@ int32_t aes_decrypt_cbc(const char* ciphertext, int32_t ciphertext_len, const ch
 }
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_cbc.h
+++ b/cpp/src/gandiva/encrypt_utils_cbc.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <openssl/evp.h>
+#include <cstdint>
 #include "gandiva/visibility.h"
 
 namespace gandiva {
@@ -44,8 +44,8 @@ constexpr const char* AES_CBC_NONE_MODE = "AES-CBC-NONE";
  */
 GANDIVA_EXPORT
 int32_t aes_encrypt_cbc(const char* plaintext, int32_t plaintext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        bool use_padding, unsigned char* cipher);
+                        int32_t key_len, const char* iv, int32_t iv_len, bool use_padding,
+                        unsigned char* cipher);
 
 /**
  * Decrypt data using AES-CBC algorithm with explicit padding mode
@@ -63,8 +63,7 @@ int32_t aes_encrypt_cbc(const char* plaintext, int32_t plaintext_len, const char
  */
 GANDIVA_EXPORT
 int32_t aes_decrypt_cbc(const char* ciphertext, int32_t ciphertext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        bool use_padding, unsigned char* plaintext);
+                        int32_t key_len, const char* iv, int32_t iv_len, bool use_padding,
+                        unsigned char* plaintext);
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_cbc_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_cbc_test.cc
@@ -17,8 +17,8 @@
 
 #include "gandiva/encrypt_utils_cbc.h"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <cstring>
 
 // Test PKCS#7 padding with 16-byte key
@@ -36,9 +36,9 @@ TEST(TestAesCbcEncryptUtils, TestAesEncryptDecryptPkcs7_16) {
                                                 iv, iv_len, true, cipher);
 
   unsigned char decrypted[64];
-  int32_t decrypted_len = gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   true, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, true, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -59,9 +59,9 @@ TEST(TestAesCbcEncryptUtils, TestAesEncryptDecryptPkcs7_24) {
                                                 iv, iv_len, true, cipher);
 
   unsigned char decrypted[64];
-  int32_t decrypted_len = gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   true, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, true, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -82,9 +82,9 @@ TEST(TestAesCbcEncryptUtils, TestAesEncryptDecryptPkcs7_32) {
                                                 iv, iv_len, true, cipher);
 
   unsigned char decrypted[64];
-  int32_t decrypted_len = gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   true, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, true, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -105,9 +105,9 @@ TEST(TestAesCbcEncryptUtils, TestAesEncryptDecryptNoPadding_16) {
                                                 iv, iv_len, false, cipher);
 
   unsigned char decrypted[64];
-  int32_t decrypted_len = gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   false, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_cbc(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, false, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -125,8 +125,8 @@ TEST(TestAesCbcEncryptUtils, TestInvalidIVLength) {
   unsigned char cipher[64];
 
   try {
-    gandiva::aes_encrypt_cbc(to_encrypt, to_encrypt_len, key, key_len,
-                             iv, iv_len, true, cipher);
+    gandiva::aes_encrypt_cbc(to_encrypt, to_encrypt_len, key, key_len, iv, iv_len, true,
+                             cipher);
     FAIL() << "Expected std::runtime_error";
   } catch (const std::runtime_error& e) {
     EXPECT_THAT(e.what(), testing::HasSubstr("Invalid IV length for AES-CBC"));
@@ -145,13 +145,10 @@ TEST(TestAesCbcEncryptUtils, TestInvalidKeyLength) {
   unsigned char cipher[64];
 
   try {
-    gandiva::aes_encrypt_cbc(to_encrypt, to_encrypt_len, key, key_len,
-                             iv, iv_len, true, cipher);
+    gandiva::aes_encrypt_cbc(to_encrypt, to_encrypt_len, key, key_len, iv, iv_len, true,
+                             cipher);
     FAIL() << "Expected std::runtime_error";
   } catch (const std::runtime_error& e) {
     EXPECT_THAT(e.what(), testing::HasSubstr("Unsupported key length for AES-CBC"));
   }
 }
-
-
-

--- a/cpp/src/gandiva/encrypt_utils_common.cc
+++ b/cpp/src/gandiva/encrypt_utils_common.cc
@@ -17,14 +17,14 @@
 
 #include "gandiva/encrypt_utils_common.h"
 #include <openssl/err.h>
-#include <string>
 #include <cstring>
+#include <string>
 
 namespace gandiva {
 
 std::string get_openssl_error_string() {
   std::string error_string;
-  unsigned long error_code;
+  unsigned long error_code;  // NOLINT(runtime/int)
   char error_buffer[256];
 
   // Loop through all errors in the queue
@@ -43,4 +43,3 @@ std::string get_openssl_error_string() {
 }
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_common.h
+++ b/cpp/src/gandiva/encrypt_utils_common.h
@@ -24,12 +24,13 @@ namespace gandiva {
 
 /// @brief Get a human-readable error string from OpenSSL's error queue.
 /// @details Retrieves all errors from the OpenSSL error queue and concatenates them
-///          with "; " as a separator. This ensures complete error information is captured.
-/// @return A string describing all OpenSSL errors in the queue, or "Unknown OpenSSL error"
+///          with "; " as a separator. This ensures complete error information is
+///          captured.
+/// @return A string describing all OpenSSL errors in the queue, or "Unknown OpenSSL
+/// error"
 ///         if no error is available.
 std::string get_openssl_error_string();
 
 }  // namespace gandiva
 
 #endif  // GANDIVA_ENCRYPT_UTILS_COMMON_H
-

--- a/cpp/src/gandiva/encrypt_utils_common_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_common_test.cc
@@ -17,8 +17,8 @@
 
 #include "gandiva/encrypt_utils_common.h"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <openssl/err.h>
 #include <openssl/evp.h>
 
@@ -92,4 +92,3 @@ TEST(TestOpenSSLErrorUtils, TestErrorQueueDrained) {
 
   EXPECT_EQ(second_call, "Unknown OpenSSL error");
 }
-

--- a/cpp/src/gandiva/encrypt_utils_ecb.cc
+++ b/cpp/src/gandiva/encrypt_utils_ecb.cc
@@ -16,12 +16,12 @@
 // under the License.
 
 #include "gandiva/encrypt_utils_ecb.h"
-#include "gandiva/encrypt_utils_common.h"
 #include <openssl/aes.h>
 #include <openssl/err.h>
-#include <stdexcept>
 #include <cstring>
 #include <sstream>
+#include <stdexcept>
+#include "gandiva/encrypt_utils_common.h"
 
 namespace gandiva {
 
@@ -145,4 +145,3 @@ int32_t aes_decrypt_ecb(const char* ciphertext, int32_t ciphertext_len, const ch
 }
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_ecb.h
+++ b/cpp/src/gandiva/encrypt_utils_ecb.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <openssl/evp.h>
+#include <cstdint>
 #include "gandiva/visibility.h"
 
 namespace gandiva {
@@ -67,4 +67,3 @@ int32_t aes_decrypt_ecb(const char* ciphertext, int32_t ciphertext_len, const ch
                         int32_t key_len, bool use_padding, unsigned char* plaintext);
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_ecb_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_ecb_test.cc
@@ -30,11 +30,13 @@ TEST(TestAesEcbEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_1[64];
 
-  int32_t cipher_1_len = gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_1);
+  int32_t cipher_1_len =
+      gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_1);
 
   unsigned char decrypted_1[64];
-  int32_t decrypted_1_len = gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_1),
-                                                     cipher_1_len, key, key_len, true, decrypted_1);
+  int32_t decrypted_1_len =
+      gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_1), cipher_1_len, key,
+                               key_len, true, decrypted_1);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_1), decrypted_1_len));
@@ -48,11 +50,13 @@ TEST(TestAesEcbEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_2[64];
 
-  int32_t cipher_2_len = gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_2);
+  int32_t cipher_2_len =
+      gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_2);
 
   unsigned char decrypted_2[64];
-  int32_t decrypted_2_len = gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_2),
-                                                     cipher_2_len, key, key_len, true, decrypted_2);
+  int32_t decrypted_2_len =
+      gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_2), cipher_2_len, key,
+                               key_len, true, decrypted_2);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_2), decrypted_2_len));
@@ -66,11 +70,13 @@ TEST(TestAesEcbEncryptUtils, TestAesEncryptDecrypt) {
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_3[64];
 
-  int32_t cipher_3_len = gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_3);
+  int32_t cipher_3_len =
+      gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_3);
 
   unsigned char decrypted_3[64];
-  int32_t decrypted_3_len = gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_3),
-                                                     cipher_3_len, key, key_len, true, decrypted_3);
+  int32_t decrypted_3_len =
+      gandiva::aes_decrypt_ecb(reinterpret_cast<const char*>(cipher_3), cipher_3_len, key,
+                               key_len, true, decrypted_3);
 
   EXPECT_EQ(std::string(reinterpret_cast<const char*>(to_encrypt), to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted_3), decrypted_3_len));
@@ -88,13 +94,16 @@ TEST(TestAesEcbEncryptUtils, TestAesEncryptDecrypt) {
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_4[64];
-  ASSERT_THROW({
-        gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_4);
-    }, std::runtime_error);
+  ASSERT_THROW(
+      {
+        gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true,
+                                 cipher_4);
+      },
+      std::runtime_error);
 
-  ASSERT_THROW({
-        gandiva::aes_decrypt_ecb(cipher, cipher_len, key, key_len, true, plain_text);
-    }, std::runtime_error);
+  ASSERT_THROW(
+      { gandiva::aes_decrypt_ecb(cipher, cipher_len, key, key_len, true, plain_text); },
+      std::runtime_error);
 
   key = "12345678";
   to_encrypt = "New\ntest\nstring";
@@ -103,11 +112,13 @@ TEST(TestAesEcbEncryptUtils, TestAesEncryptDecrypt) {
   to_encrypt_len =
       static_cast<int32_t>(strlen(reinterpret_cast<const char*>(to_encrypt)));
   unsigned char cipher_5[64];
-  ASSERT_THROW({
-        gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true, cipher_5);
-    }, std::runtime_error);
-  ASSERT_THROW({
-        gandiva::aes_decrypt_ecb(cipher, cipher_len, key, key_len, true, plain_text);
-    }, std::runtime_error);
+  ASSERT_THROW(
+      {
+        gandiva::aes_encrypt_ecb(to_encrypt, to_encrypt_len, key, key_len, true,
+                                 cipher_5);
+      },
+      std::runtime_error);
+  ASSERT_THROW(
+      { gandiva::aes_decrypt_ecb(cipher, cipher_len, key, key_len, true, plain_text); },
+      std::runtime_error);
 }
-

--- a/cpp/src/gandiva/encrypt_utils_gcm.cc
+++ b/cpp/src/gandiva/encrypt_utils_gcm.cc
@@ -16,12 +16,12 @@
 // under the License.
 
 #include "gandiva/encrypt_utils_gcm.h"
-#include "gandiva/encrypt_utils_common.h"
 #include <openssl/aes.h>
 #include <openssl/err.h>
-#include <stdexcept>
 #include <cstring>
 #include <sstream>
+#include <stdexcept>
+#include "gandiva/encrypt_utils_common.h"
 
 namespace gandiva {
 
@@ -47,10 +47,9 @@ const EVP_CIPHER* get_gcm_cipher_algo(int32_t key_length) {
 }  // namespace
 
 GANDIVA_EXPORT
-int32_t aes_encrypt_gcm(const char* plaintext, int32_t plaintext_len,
-                        const char* key, int32_t key_len, const char* iv,
-                        int32_t iv_len, const char* aad, int32_t aad_len,
-                        unsigned char* cipher) {
+int32_t aes_encrypt_gcm(const char* plaintext, int32_t plaintext_len, const char* key,
+                        int32_t key_len, const char* iv, int32_t iv_len, const char* aad,
+                        int32_t aad_len, unsigned char* cipher) {
   if (iv_len <= 0) {
     throw std::runtime_error(
         "Invalid IV length for AES-GCM: IV length must be greater than 0");
@@ -125,10 +124,9 @@ int32_t aes_encrypt_gcm(const char* plaintext, int32_t plaintext_len,
 }
 
 GANDIVA_EXPORT
-int32_t aes_decrypt_gcm(const char* ciphertext, int32_t ciphertext_len,
-                        const char* key, int32_t key_len, const char* iv,
-                        int32_t iv_len, const char* aad, int32_t aad_len,
-                        unsigned char* plaintext) {
+int32_t aes_decrypt_gcm(const char* ciphertext, int32_t ciphertext_len, const char* key,
+                        int32_t key_len, const char* iv, int32_t iv_len, const char* aad,
+                        int32_t aad_len, unsigned char* plaintext) {
   if (iv_len <= 0) {
     throw std::runtime_error(
         "Invalid IV length for AES-GCM: IV length must be greater than 0");
@@ -211,4 +209,3 @@ int32_t aes_decrypt_gcm(const char* ciphertext, int32_t ciphertext_len,
 }
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_gcm.h
+++ b/cpp/src/gandiva/encrypt_utils_gcm.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#include <cstdint>
 #include <openssl/evp.h>
+#include <cstdint>
 #include "gandiva/visibility.h"
 
 namespace gandiva {
@@ -40,14 +40,15 @@ constexpr int32_t GCM_TAG_LENGTH = 16;
  * @param iv_len Length of IV in bytes
  * @param aad Optional additional authenticated data (can be null)
  * @param aad_len Length of AAD in bytes (0 if aad is null)
- * @param cipher Output buffer for encrypted data (must be at least plaintext_len + 16 bytes)
+ * @param cipher Output buffer for encrypted data (must be at least plaintext_len + 16
+ * bytes)
  * @return Length of encrypted data in bytes (plaintext_len + 16 for the tag)
  * @throws std::runtime_error on encryption failure or invalid parameters
  */
 GANDIVA_EXPORT
 int32_t aes_encrypt_gcm(const char* plaintext, int32_t plaintext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        const char* aad, int32_t aad_len, unsigned char* cipher);
+                        int32_t key_len, const char* iv, int32_t iv_len, const char* aad,
+                        int32_t aad_len, unsigned char* cipher);
 
 /**
  * Decrypt data using AES-GCM algorithm
@@ -62,12 +63,12 @@ int32_t aes_encrypt_gcm(const char* plaintext, int32_t plaintext_len, const char
  * @param aad_len Length of AAD in bytes (0 if aad is null)
  * @param plaintext Output buffer for decrypted data
  * @return Length of decrypted data in bytes (ciphertext_len - 16)
- * @throws std::runtime_error on decryption failure, invalid parameters, or tag verification failure
+ * @throws std::runtime_error on decryption failure, invalid parameters, or tag
+ * verification failure
  */
 GANDIVA_EXPORT
 int32_t aes_decrypt_gcm(const char* ciphertext, int32_t ciphertext_len, const char* key,
-                        int32_t key_len, const char* iv, int32_t iv_len,
-                        const char* aad, int32_t aad_len, unsigned char* plaintext);
+                        int32_t key_len, const char* iv, int32_t iv_len, const char* aad,
+                        int32_t aad_len, unsigned char* plaintext);
 
 }  // namespace gandiva
-

--- a/cpp/src/gandiva/encrypt_utils_gcm_test.cc
+++ b/cpp/src/gandiva/encrypt_utils_gcm_test.cc
@@ -17,8 +17,8 @@
 
 #include "gandiva/encrypt_utils_gcm.h"
 
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
+#include <gtest/gtest.h>
 #include <cstring>
 
 // Test IV-only GCM with 16-byte key
@@ -39,9 +39,9 @@ TEST(TestAesGcmEncryptUtils, TestAesEncryptDecryptIvOnly_16) {
   EXPECT_EQ(cipher_len, to_encrypt_len + 16);
 
   unsigned char decrypted[128];
-  int32_t decrypted_len = gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   nullptr, 0, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, nullptr, 0, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -66,9 +66,9 @@ TEST(TestAesGcmEncryptUtils, TestAesEncryptDecryptWithAad_16) {
   EXPECT_EQ(cipher_len, to_encrypt_len + 16);
 
   unsigned char decrypted[128];
-  int32_t decrypted_len = gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   aad, aad_len, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, aad, aad_len, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -89,9 +89,9 @@ TEST(TestAesGcmEncryptUtils, TestAesEncryptDecryptIvOnly_24) {
                                                 iv, iv_len, nullptr, 0, cipher);
 
   unsigned char decrypted[128];
-  int32_t decrypted_len = gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   nullptr, 0, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, nullptr, 0, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -112,9 +112,9 @@ TEST(TestAesGcmEncryptUtils, TestAesEncryptDecryptIvOnly_32) {
                                                 iv, iv_len, nullptr, 0, cipher);
 
   unsigned char decrypted[128];
-  int32_t decrypted_len = gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher),
-                                                   cipher_len, key, key_len, iv, iv_len,
-                                                   nullptr, 0, decrypted);
+  int32_t decrypted_len =
+      gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher), cipher_len, key,
+                               key_len, iv, iv_len, nullptr, 0, decrypted);
 
   EXPECT_EQ(std::string(to_encrypt, to_encrypt_len),
             std::string(reinterpret_cast<const char*>(decrypted), decrypted_len));
@@ -138,9 +138,8 @@ TEST(TestAesGcmEncryptUtils, TestTagVerificationFailure) {
   cipher[cipher_len - 1] ^= 0xFF;
 
   unsigned char decrypted[128];
-  EXPECT_THROW(gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher),
-                                        cipher_len, key, key_len, iv, iv_len,
-                                        nullptr, 0, decrypted),
+  EXPECT_THROW(gandiva::aes_decrypt_gcm(reinterpret_cast<const char*>(cipher), cipher_len,
+                                        key, key_len, iv, iv_len, nullptr, 0, decrypted),
                std::runtime_error);
 }
 
@@ -155,8 +154,7 @@ TEST(TestAesGcmEncryptUtils, TestInvalidIvLength) {
   auto to_encrypt_len = static_cast<int32_t>(strlen(to_encrypt));
   unsigned char cipher[128];
 
-  EXPECT_THROW(gandiva::aes_encrypt_gcm(to_encrypt, to_encrypt_len, key, key_len,
-                                        iv, iv_len, nullptr, 0, cipher),
+  EXPECT_THROW(gandiva::aes_encrypt_gcm(to_encrypt, to_encrypt_len, key, key_len, iv,
+                                        iv_len, nullptr, 0, cipher),
                std::runtime_error);
 }
-

--- a/cpp/src/gandiva/engine.cc
+++ b/cpp/src/gandiva/engine.cc
@@ -228,7 +228,7 @@ Result<std::unique_ptr<llvm::orc::LLJIT>> BuildJIT(
 #endif
 
   jit_builder.setJITTargetMachineBuilder(std::move(jtmb));
-  jit_builder.setDataLayout(std::make_optional(data_layout));
+  jit_builder.setDataLayout(data_layout);
 
   if (object_cache.has_value()) {
     jit_builder.setCompileFunctionCreator(

--- a/cpp/src/gandiva/function_registry_string.cc
+++ b/cpp/src/gandiva/function_registry_string.cc
@@ -515,21 +515,23 @@ std::vector<NativeFunction> GetStringFunctionRegistry() {
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       // Parameters: data, key, mode, iv (e.g. CBC mode)
-      NativeFunction("encrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary()}, binary(),
-                     kResultNullIfNull, "gdv_fn_encrypt_dispatcher_4args",
+      NativeFunction("encrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary()},
+                     binary(), kResultNullIfNull, "gdv_fn_encrypt_dispatcher_4args",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
-      NativeFunction("decrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary()}, binary(),
-                     kResultNullIfNull, "gdv_fn_decrypt_dispatcher_4args",
+      NativeFunction("decrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary()},
+                     binary(), kResultNullIfNull, "gdv_fn_decrypt_dispatcher_4args",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       // Parameters: data, key, mode, iv, fifth_argument (e.g. GCM mode)
-      NativeFunction("encrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary(), binary()}, binary(),
-                     kResultNullIfNull, "gdv_fn_encrypt_dispatcher_5args",
+      NativeFunction("encrypt", {},
+                     DataTypeVector{binary(), binary(), utf8(), binary(), binary()},
+                     binary(), kResultNullIfNull, "gdv_fn_encrypt_dispatcher_5args",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
-      NativeFunction("decrypt", {}, DataTypeVector{binary(), binary(), utf8(), binary(), binary()}, binary(),
-                     kResultNullIfNull, "gdv_fn_decrypt_dispatcher_5args",
+      NativeFunction("decrypt", {},
+                     DataTypeVector{binary(), binary(), utf8(), binary(), binary()},
+                     binary(), kResultNullIfNull, "gdv_fn_decrypt_dispatcher_5args",
                      NativeFunction::kNeedsContext | NativeFunction::kCanReturnErrors),
 
       NativeFunction("mask_first_n", {}, DataTypeVector{utf8(), int32()}, utf8(),

--- a/cpp/src/gandiva/gdv_function_stubs.cc
+++ b/cpp/src/gandiva/gdv_function_stubs.cc
@@ -30,9 +30,9 @@
 #include "arrow/util/double_conversion.h"
 #include "arrow/util/value_parsing.h"
 
-#include "gandiva/encrypt_utils_ecb.h"
-#include "gandiva/encrypt_utils_cbc.h"
 #include "gandiva/encrypt_mode_dispatcher.h"
+#include "gandiva/encrypt_utils_cbc.h"
+#include "gandiva/encrypt_utils_ecb.h"
 #include "gandiva/engine.h"
 #include "gandiva/exported_funcs.h"
 #include "gandiva/in_holder.h"
@@ -309,8 +309,6 @@ CAST_NUMERIC_FROM_VARBINARY(double, arrow::DoubleType, FLOAT8)
 
 #undef GDV_FN_CAST_VARCHAR_INTEGER
 #undef GDV_FN_CAST_VARCHAR_REAL
-
-
 
 GANDIVA_EXPORT
 const char* gdv_mask_first_n_utf8_int32(int64_t context, const char* data,
@@ -768,12 +766,9 @@ namespace gandiva {
 // This is called by the LLVM engine with string calling convention
 // WARNING: This function is for backward compatibility only. Encrypted binary
 // data is not guaranteed to be valid UTF-8. Use binary signatures for new code.
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_aes_encrypt_ecb_legacy(int64_t context, const char* data,
-                                          int32_t data_len,
-                                          const char* key_data,
-                                          int32_t key_data_len,
-                                          int32_t* out_len) {
+extern "C" GANDIVA_EXPORT const char* gdv_fn_aes_encrypt_ecb_legacy(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, int32_t* out_len) {
   // Delegate to the core implementation with ECB mode
   // This function is ECB-only, so we enforce the mode
   const char* mode = "AES-ECB";
@@ -795,12 +790,9 @@ const char* gdv_fn_aes_encrypt_ecb_legacy(int64_t context, const char* data,
 // This is called by the LLVM engine with string calling convention
 // WARNING: This function is for backward compatibility only. Decrypted data
 // may not be valid UTF-8. Use binary signatures for new code.
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_aes_decrypt_ecb_legacy(int64_t context, const char* data,
-                                          int32_t data_len,
-                                          const char* key_data,
-                                          int32_t key_data_len,
-                                          int32_t* out_len) {
+extern "C" GANDIVA_EXPORT const char* gdv_fn_aes_decrypt_ecb_legacy(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, int32_t* out_len) {
   // Delegate to the core implementation with ECB mode
   // This function is ECB-only, so we enforce the mode
   const char* mode = "AES-ECB";
@@ -819,52 +811,43 @@ const char* gdv_fn_aes_decrypt_ecb_legacy(int64_t context, const char* data,
 }
 
 // The 3- and 4-arg signatures exist to support optional IV and other arguments
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_3args(
+extern "C" GANDIVA_EXPORT const char* gdv_fn_encrypt_dispatcher_3args(
     int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
+    int32_t key_data_len, const char* mode, int32_t mode_len, int32_t* out_len) {
+  return gdv_fn_encrypt_dispatcher_5args(context, data, data_len, key_data, key_data_len,
+                                         mode, mode_len, nullptr, 0, nullptr, 0, out_len);
+}
+
+extern "C" GANDIVA_EXPORT const char* gdv_fn_decrypt_dispatcher_3args(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, const char* mode, int32_t mode_len, int32_t* out_len) {
+  return gdv_fn_decrypt_dispatcher_5args(context, data, data_len, key_data, key_data_len,
+                                         mode, mode_len, nullptr, 0, nullptr, 0, out_len);
+}
+
+extern "C" GANDIVA_EXPORT const char* gdv_fn_encrypt_dispatcher_4args(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, const char* mode, int32_t mode_len, const char* iv_data,
+    int32_t iv_data_len, int32_t* out_len) {
+  return gdv_fn_encrypt_dispatcher_5args(context, data, data_len, key_data, key_data_len,
+                                         mode, mode_len, iv_data, iv_data_len, nullptr, 0,
+                                         out_len);
+}
+
+extern "C" GANDIVA_EXPORT const char* gdv_fn_decrypt_dispatcher_4args(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, const char* mode, int32_t mode_len, const char* iv_data,
+    int32_t iv_data_len, int32_t* out_len) {
+  return gdv_fn_decrypt_dispatcher_5args(context, data, data_len, key_data, key_data_len,
+                                         mode, mode_len, iv_data, iv_data_len, nullptr, 0,
+                                         out_len);
+}
+
+extern "C" GANDIVA_EXPORT const char* gdv_fn_encrypt_dispatcher_5args(
+    int64_t context, const char* data, int32_t data_len, const char* key_data,
+    int32_t key_data_len, const char* mode, int32_t mode_len, const char* iv_data,
+    int32_t iv_data_len, const char* fifth_argument, int32_t fifth_argument_len,
     int32_t* out_len) {
-  return gdv_fn_encrypt_dispatcher_5args(
-      context, data, data_len, key_data, key_data_len, mode, mode_len, nullptr,
-      0, nullptr, 0, out_len);
-}
-
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_3args(
-    int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
-    int32_t* out_len) {
-  return gdv_fn_decrypt_dispatcher_5args(
-      context, data, data_len, key_data, key_data_len, mode, mode_len, nullptr,
-      0, nullptr, 0, out_len);
-}
-
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_4args(
-    int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
-    const char* iv_data, int32_t iv_data_len, int32_t* out_len) {
-  return gdv_fn_encrypt_dispatcher_5args(
-      context, data, data_len, key_data, key_data_len, mode, mode_len, iv_data,
-      iv_data_len, nullptr, 0, out_len);
-}
-
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_4args(
-    int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
-    const char* iv_data, int32_t iv_data_len, int32_t* out_len) {
-  return gdv_fn_decrypt_dispatcher_5args(
-      context, data, data_len, key_data, key_data_len, mode, mode_len, iv_data,
-      iv_data_len, nullptr, 0, out_len);
-}
-
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_5args(
-    int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
-    const char* iv_data, int32_t iv_data_len, const char* fifth_argument,
-    int32_t fifth_argument_len, int32_t* out_len) {
   try {
     // Allocate extra 16 bytes for AES block padding (PKCS7 padding can add
     // up to 16 bytes for a 128-bit block cipher)
@@ -872,13 +855,12 @@ const char* gdv_fn_encrypt_dispatcher_5args(
     auto* output = reinterpret_cast<unsigned char*>(
         gdv_fn_context_arena_malloc(context, data_len + 16));
     if (output == nullptr) {
-      throw std::runtime_error(
-          "Memory allocation failed for encryption output");
+      throw std::runtime_error("Memory allocation failed for encryption output");
     }
 
     int32_t cipher_len = EncryptModeDispatcher::encrypt(
-        data, data_len, key_data, key_data_len, mode, mode_len, iv_data,
-        iv_data_len, fifth_argument, fifth_argument_len, output);
+        data, data_len, key_data, key_data_len, mode, mode_len, iv_data, iv_data_len,
+        fifth_argument, fifth_argument_len, output);
 
     *out_len = cipher_len;
     return reinterpret_cast<const char*>(output);
@@ -889,23 +871,21 @@ const char* gdv_fn_encrypt_dispatcher_5args(
   }
 }
 
-extern "C" GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_5args(
+extern "C" GANDIVA_EXPORT const char* gdv_fn_decrypt_dispatcher_5args(
     int64_t context, const char* data, int32_t data_len, const char* key_data,
-    int32_t key_data_len, const char* mode, int32_t mode_len,
-    const char* iv_data, int32_t iv_data_len, const char* fifth_argument,
-    int32_t fifth_argument_len, int32_t* out_len) {
+    int32_t key_data_len, const char* mode, int32_t mode_len, const char* iv_data,
+    int32_t iv_data_len, const char* fifth_argument, int32_t fifth_argument_len,
+    int32_t* out_len) {
   try {
-    auto* output = reinterpret_cast<unsigned char*>(
-        gdv_fn_context_arena_malloc(context, data_len));
+    auto* output =
+        reinterpret_cast<unsigned char*>(gdv_fn_context_arena_malloc(context, data_len));
     if (output == nullptr) {
-      throw std::runtime_error(
-          "Memory allocation failed for decryption output");
+      throw std::runtime_error("Memory allocation failed for decryption output");
     }
 
     int32_t plaintext_len = EncryptModeDispatcher::decrypt(
-        data, data_len, key_data, key_data_len, mode, mode_len, iv_data,
-        iv_data_len, fifth_argument, fifth_argument_len, output);
+        data, data_len, key_data, key_data_len, mode, mode_len, iv_data, iv_data_len,
+        fifth_argument, fifth_argument_len, output);
 
     *out_len = plaintext_len;
     return reinterpret_cast<const char*>(output);
@@ -1164,8 +1144,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_encrypt_dispatcher_3args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_encrypt_dispatcher_3args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_encrypt_dispatcher_3args));
 
   // gdv_fn_decrypt_dispatcher_3args (data, key, mode)
@@ -1181,8 +1160,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_decrypt_dispatcher_3args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_decrypt_dispatcher_3args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_decrypt_dispatcher_3args));
 
   // gdv_fn_encrypt_dispatcher_4args (data, key, mode, iv)
@@ -1200,8 +1178,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_encrypt_dispatcher_4args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_encrypt_dispatcher_4args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_encrypt_dispatcher_4args));
 
   // gdv_fn_decrypt_dispatcher_4args (data, key, mode, iv)
@@ -1219,8 +1196,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_decrypt_dispatcher_4args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_decrypt_dispatcher_4args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_decrypt_dispatcher_4args));
 
   // gdv_fn_encrypt_dispatcher_5args (data, key, mode, iv,
@@ -1241,8 +1217,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_encrypt_dispatcher_5args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_encrypt_dispatcher_5args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_encrypt_dispatcher_5args));
 
   // gdv_fn_decrypt_dispatcher_5args (data, key, mode, iv,
@@ -1263,8 +1238,7 @@ arrow::Status ExportedStubFunctions::AddMappings(Engine* engine) const {
   };
 
   engine->AddGlobalMappingForFunc(
-      "gdv_fn_decrypt_dispatcher_5args",
-      types->i8_ptr_type() /*return_type*/, args,
+      "gdv_fn_decrypt_dispatcher_5args", types->i8_ptr_type() /*return_type*/, args,
       reinterpret_cast<void*>(gdv_fn_decrypt_dispatcher_5args));
 
   // gdv_mask_first_n and gdv_mask_last_n

--- a/cpp/src/gandiva/gdv_function_stubs.h
+++ b/cpp/src/gandiva/gdv_function_stubs.h
@@ -192,62 +192,60 @@ double gdv_fn_castFLOAT8_varbinary(gdv_int64 context, const char* in, int32_t in
 // Legacy wrappers for string-based AES-ECB signatures
 GANDIVA_EXPORT
 const char* gdv_fn_aes_encrypt_ecb_legacy(int64_t context, const char* data,
-                                          int32_t data_len,
-                                          const char* key_data,
-                                          int32_t key_data_len,
-                                          int32_t* out_len);
+                                          int32_t data_len, const char* key_data,
+                                          int32_t key_data_len, int32_t* out_len);
 
 GANDIVA_EXPORT
 const char* gdv_fn_aes_decrypt_ecb_legacy(int64_t context, const char* data,
-                                          int32_t data_len,
-                                          const char* key_data,
-                                          int32_t key_data_len,
-                                          int32_t* out_len);
+                                          int32_t data_len, const char* key_data,
+                                          int32_t key_data_len, int32_t* out_len);
 
 // 3-argument dispatcher: (data, key, mode)
 GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_3args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, int32_t* out_len);
+const char* gdv_fn_encrypt_dispatcher_3args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_3args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, int32_t* out_len);
+const char* gdv_fn_decrypt_dispatcher_3args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, int32_t* out_len);
 
 // 4-argument dispatcher: (data, key, mode, iv)
 GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_4args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, const char* iv_data, int32_t iv_data_len,
-    int32_t* out_len);
+const char* gdv_fn_encrypt_dispatcher_4args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, const char* iv_data,
+                                            int32_t iv_data_len, int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_4args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, const char* iv_data, int32_t iv_data_len,
-    int32_t* out_len);
+const char* gdv_fn_decrypt_dispatcher_4args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, const char* iv_data,
+                                            int32_t iv_data_len, int32_t* out_len);
 
 // 5-argument dispatcher: (data, key, mode, iv, fifth_argument)
 GANDIVA_EXPORT
-const char* gdv_fn_encrypt_dispatcher_5args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, const char* iv_data, int32_t iv_data_len,
-    const char* fifth_argument, int32_t fifth_argument_len,
-    int32_t* out_len);
+const char* gdv_fn_encrypt_dispatcher_5args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, const char* iv_data,
+                                            int32_t iv_data_len,
+                                            const char* fifth_argument,
+                                            int32_t fifth_argument_len, int32_t* out_len);
 
 GANDIVA_EXPORT
-const char* gdv_fn_decrypt_dispatcher_5args(
-    int64_t context, const char* data, int32_t data_len,
-    const char* key_data, int32_t key_data_len, const char* mode,
-    int32_t mode_len, const char* iv_data, int32_t iv_data_len,
-    const char* fifth_argument, int32_t fifth_argument_len,
-    int32_t* out_len);
+const char* gdv_fn_decrypt_dispatcher_5args(int64_t context, const char* data,
+                                            int32_t data_len, const char* key_data,
+                                            int32_t key_data_len, const char* mode,
+                                            int32_t mode_len, const char* iv_data,
+                                            int32_t iv_data_len,
+                                            const char* fifth_argument,
+                                            int32_t fifth_argument_len, int32_t* out_len);
 
 GANDIVA_EXPORT
 const char* gdv_mask_first_n_utf8_int32(int64_t context, const char* data,

--- a/cpp/src/gandiva/gdv_function_stubs_test.cc
+++ b/cpp/src/gandiva/gdv_function_stubs_test.cc
@@ -22,10 +22,10 @@
 #include <gtest/gtest.h>
 
 #include "arrow/util/logging.h"
-#include "gandiva/execution_context.h"
-#include "gandiva/encrypt_utils_ecb.h"
 #include "gandiva/encrypt_utils_cbc.h"
+#include "gandiva/encrypt_utils_ecb.h"
 #include "gandiva/encrypt_utils_gcm.h"
+#include "gandiva/execution_context.h"
 
 namespace gandiva {
 
@@ -1360,16 +1360,15 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt16) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &cipher_len);
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &cipher_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecrypt24) {
@@ -1384,17 +1383,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt24) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key24.c_str(), key24_len, mode.c_str(),
-      mode_len, &cipher_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key24.c_str(),
+                                      key24_len, mode.c_str(), mode_len, &cipher_len);
 
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key24.c_str(), key24_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key24.c_str(),
+                                      key24_len, mode.c_str(), mode_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecrypt32) {
@@ -1409,17 +1407,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecrypt32) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key32.c_str(), key32_len, mode.c_str(),
-      mode_len, &cipher_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key32.c_str(),
+                                      key32_len, mode.c_str(), mode_len, &cipher_len);
 
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key32.c_str(), key32_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key32.c_str(),
+                                      key32_len, mode.c_str(), mode_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
@@ -1435,16 +1432,14 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptValidation) {
   std::string cipher = "12345678abcdefgh12345678abcdefghb";
   auto cipher_len = static_cast<int32_t>(cipher.length());
 
-  gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len,
-                                      key33.c_str(), key33_len, mode.c_str(),
-                                      mode_len, &cipher_len);
+  gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key33.c_str(),
+                                  key33_len, mode.c_str(), mode_len, &cipher_len);
   EXPECT_THAT(ctx.get_error(),
               ::testing::HasSubstr("Unsupported key length for AES-ECB"));
   ctx.Reset();
 
-  gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher.c_str(), cipher_len,
-                                      key33.c_str(), key33_len, mode.c_str(),
-                                      mode_len, &decrypted_len);
+  gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher.c_str(), cipher_len, key33.c_str(),
+                                  key33_len, mode.c_str(), mode_len, &decrypted_len);
   EXPECT_THAT(ctx.get_error(),
               ::testing::HasSubstr("Unsupported key length for AES-ECB"));
   ctx.Reset();
@@ -1463,17 +1458,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptModeEcb) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &cipher_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &decrypted_len);
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecryptModeValidation) {
@@ -1489,23 +1483,19 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptModeValidation) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   // Test encrypt with invalid mode
-  gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len,
-                                      key16.c_str(), key16_len,
-                                      invalid_mode.c_str(), invalid_mode_len,
-                                      &cipher_len);
-  EXPECT_THAT(ctx.get_error(),
-              ::testing::HasSubstr("Unsupported encryption mode"));
+  gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                  key16_len, invalid_mode.c_str(), invalid_mode_len,
+                                  &cipher_len);
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Unsupported encryption mode"));
   ctx.Reset();
 
   // Test decrypt with invalid mode
   std::string cipher = "12345678abcdefgh12345678abcdefgh";
   auto cipher_len_val = static_cast<int32_t>(cipher.length());
-  gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher.c_str(), cipher_len_val,
-                                      key16.c_str(), key16_len,
-                                      invalid_mode.c_str(), invalid_mode_len,
-                                      &decrypted_len);
-  EXPECT_THAT(ctx.get_error(),
-              ::testing::HasSubstr("Unsupported decryption mode"));
+  gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher.c_str(), cipher_len_val, key16.c_str(),
+                                  key16_len, invalid_mode.c_str(), invalid_mode_len,
+                                  &decrypted_len);
+  EXPECT_THAT(ctx.get_error(), ::testing::HasSubstr("Unsupported decryption mode"));
   ctx.Reset();
 }
 
@@ -1525,17 +1515,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptGcmIvOnly) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   const char* cipher = gdv_fn_encrypt_dispatcher_5args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, nullptr, 0, &cipher_len);
+      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, nullptr, 0, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
   const char* decrypted_value = gdv_fn_decrypt_dispatcher_5args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, nullptr, 0, &decrypted_len);
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, nullptr, 0, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 TEST(TestGdvFnStubs, TestAesEncryptDecryptGcmWithAad) {
@@ -1555,17 +1544,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptGcmWithAad) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   const char* cipher = gdv_fn_encrypt_dispatcher_5args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, aad.c_str(), aad_len, &cipher_len);
+      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, aad.c_str(), aad_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
   const char* decrypted_value = gdv_fn_decrypt_dispatcher_5args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, aad.c_str(), aad_len, &decrypted_len);
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, aad.c_str(), aad_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 // Tests for shorthand mode: AES-ECB (defaults to PKCS7)
@@ -1581,18 +1569,17 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptShorthandEcb) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &cipher_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 // Tests for explicit mode: AES-ECB-PKCS7
@@ -1608,18 +1595,17 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptExplicitEcbPkcs7) {
   auto mode_len = static_cast<int32_t>(mode.length());
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
-  const char* cipher = gdv_fn_encrypt_dispatcher_3args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &cipher_len);
+  const char* cipher =
+      gdv_fn_encrypt_dispatcher_3args(ctx_ptr, data.c_str(), data_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
-  const char* decrypted_value = gdv_fn_decrypt_dispatcher_3args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, &decrypted_len);
+  const char* decrypted_value =
+      gdv_fn_decrypt_dispatcher_3args(ctx_ptr, cipher, cipher_len, key16.c_str(),
+                                      key16_len, mode.c_str(), mode_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 // Tests for shorthand mode: AES-CBC (defaults to PKCS7)
@@ -1638,17 +1624,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptShorthandCbc) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   const char* cipher = gdv_fn_encrypt_dispatcher_4args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &cipher_len);
+      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
   const char* decrypted_value = gdv_fn_decrypt_dispatcher_4args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &decrypted_len);
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 // Tests for explicit mode: AES-CBC-PKCS7
@@ -1667,17 +1652,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptExplicitCbcPkcs7) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   const char* cipher = gdv_fn_encrypt_dispatcher_4args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &cipher_len);
+      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
   const char* decrypted_value = gdv_fn_decrypt_dispatcher_4args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &decrypted_len);
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 // Tests for explicit mode: AES-CBC-NONE (no padding)
@@ -1697,17 +1681,16 @@ TEST(TestGdvFnStubs, TestAesEncryptDecryptCbcNone) {
   int64_t ctx_ptr = reinterpret_cast<int64_t>(&ctx);
 
   const char* cipher = gdv_fn_encrypt_dispatcher_4args(
-      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &cipher_len);
+      ctx_ptr, data.c_str(), data_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &cipher_len);
   EXPECT_GT(cipher_len, 0);
 
   const char* decrypted_value = gdv_fn_decrypt_dispatcher_4args(
-      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(),
-      mode_len, iv.c_str(), iv_len, &decrypted_len);
+      ctx_ptr, cipher, cipher_len, key16.c_str(), key16_len, mode.c_str(), mode_len,
+      iv.c_str(), iv_len, &decrypted_len);
 
   EXPECT_EQ(data,
-            std::string(reinterpret_cast<const char*>(decrypted_value),
-                        decrypted_len));
+            std::string(reinterpret_cast<const char*>(decrypted_value), decrypted_len));
 }
 
 }  // namespace gandiva

--- a/cpp/src/gandiva/tests/boolean_expr_test.cc
+++ b/cpp/src/gandiva/tests/boolean_expr_test.cc
@@ -38,8 +38,8 @@ class TestBooleanExpr : public ::testing::Test {
 
 TEST_F(TestBooleanExpr, OrWithManyEqualityChecks) {
   // Test case for: field IN (-8, -7, -6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5)
-  // This tests the scenario where IN expression is rewritten as OR with many equality checks
-  // OR(=($7, -8), =($7, -7), ..., =($7, 5))
+  // This tests the scenario where IN expression is rewritten as OR with many equality
+  // checks OR(=($7, -8), =($7, -7), ..., =($7, 5))
 
   auto field0 = field("f0", int32());
   auto schema = arrow::schema({field0});
@@ -55,8 +55,10 @@ TEST_F(TestBooleanExpr, OrWithManyEqualityChecks) {
   auto lit_5 = TreeExprBuilder::MakeLiteral((int32_t)5);
   auto lit_10 = TreeExprBuilder::MakeLiteral((int32_t)10);
 
-  auto eq_minus8 = TreeExprBuilder::MakeFunction("equal", {node_f0, lit_minus8}, boolean());
-  auto eq_minus5 = TreeExprBuilder::MakeFunction("equal", {node_f0, lit_minus5}, boolean());
+  auto eq_minus8 =
+      TreeExprBuilder::MakeFunction("equal", {node_f0, lit_minus8}, boolean());
+  auto eq_minus5 =
+      TreeExprBuilder::MakeFunction("equal", {node_f0, lit_minus5}, boolean());
   auto eq_0 = TreeExprBuilder::MakeFunction("equal", {node_f0, lit_0}, boolean());
   auto eq_5 = TreeExprBuilder::MakeFunction("equal", {node_f0, lit_5}, boolean());
   auto eq_10 = TreeExprBuilder::MakeFunction("equal", {node_f0, lit_10}, boolean());
@@ -74,7 +76,7 @@ TEST_F(TestBooleanExpr, OrWithManyEqualityChecks) {
   // Expected: true for indices 1(-8), 2(-5), 3(0), 4(5), false for others
   int num_records = 7;
   auto array0 = MakeArrowArrayInt32({-10, -8, -5, 0, 5, 10, 15},
-                                     {true, true, true, true, true, true, true});
+                                    {true, true, true, true, true, true, true});
   auto exp = MakeArrowArrayBool({false, true, true, true, true, true, false},
                                 {true, true, true, true, true, true, true});
   auto in_batch = arrow::RecordBatch::Make(schema, num_records, {array0});

--- a/dev/release/rat_exclude_files.txt
+++ b/dev/release/rat_exclude_files.txt
@@ -10,6 +10,7 @@
 ci/etc/rprofile
 ci/etc/*.patch
 ci/vcpkg/*.patch
+ci/vcpkg/overlay/**
 CHANGELOG.md
 cpp/CHANGELOG_PARQUET.md
 cpp/src/arrow/c/dlpack_abi.h


### PR DESCRIPTION
## Summary

This PR fixes multiple pre-existing CI failures in the `dremio_27.0_20` branch that were causing nearly all checks to fail on any PR.

- **Lint (pre-commit)**: Apply `clang-format` to all Gandiva `encrypt_utils*` and related files; apply `cmake-format` to vcpkg portfiles (brotli, llvm, symengine); add `NOLINT(runtime/int)` for `unsigned long` required by OpenSSL API
- **ASAN/ARM64 Ubuntu compilation**: Fix `engine.cc` - pass `DataLayout` directly to `setDataLayout()` instead of `std::make_optional(data_layout)`, which is incompatible with LLVM 14's `llvm::Optional` type
- **Conda AVX2 compilation**: Fix `benchmark_util.h` - replace deprecated `benchmark::internal::Benchmark` with `benchmark::Benchmark` (newer Google Benchmark API; flagged as `-Werror`)
- **Conda Docker build**: Fix `install_gcs_testbench.sh` - install `setuptools` before `pipx` to provide `pkg_resources` required by `grpcio` wheel build
- **Windows MinGW**: Fix `msys2_setup.sh` - add `llvm` package so Gandiva can find `LLVMAlt` in MINGW64/CLANG64 environments

## Test plan

- [ ] Lint C++, Python, R, Docker, RAT — should now pass (pre-commit hooks all pass locally)
- [ ] Source Release and Merge Script — unchanged, should continue passing
- [ ] AMD64 Ubuntu ASAN UBSAN — engine.cc fix should resolve LLVM Optional type error
- [ ] ARM64 Ubuntu C++ — same engine.cc fix
- [ ] AMD64 Conda C++ AVX2 — benchmark_util.h + setuptools fixes
- [ ] Windows MinGW — LLVM package addition
- [ ] macOS builds — no changes to macOS-specific code; existing passing checks should remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)