### PR TITLE
DX-105463: [C++][Gandiva] Add TimestampIR wrapper for next_day

### DIFF
--- a/cpp/src/gandiva/timestamp_ir.cc
+++ b/cpp/src/gandiva/timestamp_ir.cc
@@ -189,6 +189,7 @@ static std::unordered_set<std::string> BuildAllFunctionNames() {
     names.insert(std::string("to_utc_timezone_timestamp") + sfx);
     names.insert(std::string("from_utc_timezone_timestamp") + sfx);
     names.insert(std::string("castVARCHAR_timestamp_int64") + sfx);
+    names.insert(std::string("next_day_from_timestamp") + sfx);
   }
   return names;
 }
@@ -457,6 +458,40 @@ Status TimestampIR::BuildTimezoneWrapper(const std::string& function_name,
   auto result_millis = ir_builder()->CreateCall(precompiled_fn, {ctx, millis, tz, tz_len});
   auto result_scaled = ir_builder()->CreateMul(result_millis, upm_const);
   auto result = ir_builder()->CreateAdd(result_scaled, remainder);
+
+  ir_builder()->CreateRet(result);
+  return Status::OK();
+}
+
+Status TimestampIR::BuildNextDayWrapper(const std::string& function_name,
+                                        const std::string& precompiled_millis_fn,
+                                        arrow::TimeUnit::type time_unit) {
+  // fn(context, ts, day_str, day_len) -> date64
+  // next_day returns the date of the next weekday (e.g. 'MO' for Monday) at midnight,
+  // so sub-ms precision is not relevant in the result — just scale the input to millis.
+  auto precompiled_fn = module()->getFunction(precompiled_millis_fn);
+  if (!precompiled_fn) {
+    return Status::Invalid("Precompiled function not found: ", precompiled_millis_fn);
+  }
+
+  auto i64 = types()->i64_type();
+  auto i32 = types()->i32_type();
+  auto i8ptr = llvm::PointerType::get(*context(), 0);
+  auto function = BuildFunction(
+      function_name, i64,
+      {{"ctx", i64}, {"ts", i64}, {"day", i8ptr}, {"day_len", i32}});
+  auto entry = llvm::BasicBlock::Create(*context(), "entry", function);
+  ir_builder()->SetInsertPoint(entry);
+
+  auto arg_iter = function->arg_begin();
+  auto ctx = &arg_iter[0];
+  auto ts = &arg_iter[1];
+  auto day = &arg_iter[2];
+  auto day_len = &arg_iter[3];
+
+  int64_t upm = UnitsPerMilli(time_unit);
+  auto millis = FloorDiv(ts, llvm::ConstantInt::get(i64, upm));
+  auto result = ir_builder()->CreateCall(precompiled_fn, {ctx, millis, day, day_len});
 
   ir_builder()->CreateRet(result);
   return Status::OK();
@@ -774,6 +809,13 @@ std::pair<llvm::Value*, llvm::Value*> TimestampIR::FloorDivRem(
       try_build(ir_name,
                    ts_ir->BuildCastVARCHARWrapper(ir_name, "castVARCHAR_timestamp_int64",
                                                    unit));
+    }
+
+    // next_day(timestamp, utf8): scale to millis, return date64
+    {
+      std::string ir_name = std::string("next_day_from_timestamp") + sfx;
+      try_build(ir_name,
+                ts_ir->BuildNextDayWrapper(ir_name, "next_day_from_timestamp", unit));
     }
   }
 

--- a/cpp/src/gandiva/timestamp_ir.h
+++ b/cpp/src/gandiva/timestamp_ir.h
@@ -113,6 +113,12 @@ class TimestampIR : public FunctionIRBuilder {
                                  const std::string& precompiled_fn,
                                  arrow::TimeUnit::type unit);
 
+  // next_day: scale ts to millis, call precompiled, return date64
+  // fn(context, ts, day_str, day_len) -> int64
+  Status BuildNextDayWrapper(const std::string& fn,
+                             const std::string& precompiled_fn,
+                             arrow::TimeUnit::type unit);
+
   // Floor division: ts / divisor rounded toward negative infinity.
   // C/LLVM SDiv truncates toward zero, which gives wrong millis for negative
   // timestamps with non-zero sub-ms components (e.g., SDiv(-456, 1000) = 0


### PR DESCRIPTION
## Summary

Fixes a silent-wrong-results correctness bug in `next_day(timestamp[us/ns], utf8)` when the relaxed `DataTypeEquals` routes non-ms timestamps through Gandiva but no IR wrapper exists.

Follow-up to #134 (TimestampIR for unit-aware timestamp support, now merged).

## Background

During end-to-end testing of #134 against real Parquet/Iceberg data (which stores timestamps as `timestamp[us]` regardless of the original SQL precision), `NEXT_DAY(ts_us, 'MO')` returned `+53425-02-28` — a date ~51,000 years in the future — instead of the correct Monday after the input date.

## Root cause

`next_day` is registered in `function_registry_datetime.cc` for both `date64` and `timestamp` via the `DATE_TYPES` macro:

```cpp
DATE_TYPES(NEXT_DAY_SAFE_NULL_IF_NULL, next_day, {})
```

But `next_day` was not included in any of the static tables in `timestamp_ir.cc` (`kExtracts`, `kTruncs`, `kDiffs`, `kCastsFromTs`, `kDateArithEntries`, `kFixedAdds`, `kCalendarAdds`). As a result, no `next_day_from_timestamp_us` / `_ns` IR wrappers were generated.

With the `DataTypeEquals` relaxation from #134, the validation step matches `timestamp[us]` against the registered `timestamp[ms]` signature. `BuildFunctionCall` then tries to remap `next_day_from_timestamp` → `next_day_from_timestamp_us`, fails to find it in `IsTimestampIRFunction`, and silently falls through to calling the precompiled millis function with raw microsecond values — yielding dates far in the future.

## Fix

Adds a `BuildNextDayWrapper` that follows the cast-from-timestamp pattern:

```
next_day_from_timestamp_us(ctx, ts_us, day_str, day_len) -> date64 {
  millis = FloorDiv(ts_us, 1000)
  return next_day_from_timestamp(ctx, millis, day_str, day_len)
}
```

No remainder recombination is needed because `next_day` returns `date64` (midnight of the next weekday), so sub-millisecond input precision is not meaningful in the result.

## Files changed

- `cpp/src/gandiva/timestamp_ir.h` — declare `BuildNextDayWrapper`
- `cpp/src/gandiva/timestamp_ir.cc` —
  - Register `next_day_from_timestamp{_us,_ns}` in `BuildAllFunctionNames`
  - Implement `BuildNextDayWrapper` (modeled after `BuildCastFromTimestampWrapper` with extra context/string/length args)
  - Call it from `AddFunctions` for each non-ms unit

## Build artifacts

Native library built and published with this fix:

- **arrow-java release:** https://github.com/dremio/arrow-java/releases/tag/v18.3.0-5d2c1e7-73313a7
- **GitHub Actions build run:** https://github.com/dremio/arrow-java/actions/runs/24584277730
- **Jenkins gandiva build:** https://jenkins.drem.io/job/custom-arrow-gandiva-build/1536/console
- **Maven artifact version:** `18.3.0-20260418002220-5d2c1e7-73313a7-dremio`

## Testing

Verified end-to-end on a local Dremio instance reading Parquet timestamp data.

**Test query:**
```sql
SELECT NEXT_DAY(ts_us, 'MO') FROM tst.dremio_ts_test;
```
where `ts_us` is a `timestamp[us]` column containing `2021-06-15 14:30:45.123456` (a Tuesday).

**Before fix (arrow-gandiva 18.3.0-...-28932a0-dremio):**
```
+53425-02-28
```
(microseconds interpreted as milliseconds → date ~51,000 years in the future)

**After fix (arrow-gandiva 18.3.0-...-73313a7-dremio):**
```
2021-06-21
```
(correct Monday after 2021-06-15)

## Are there user-facing changes?

No API changes. `NEXT_DAY` on `TIMESTAMP(6)` / `TIMESTAMP(9)` columns now returns correct results instead of dates ~51,000 years in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)