### PR TITLE
DX-116527 Update CHR to work with unicode

### DIFF
--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1394,7 +1394,7 @@ FORCE_INLINE
 const char* chr_int64(gdv_int64 context, gdv_int64 in, gdv_int32* out_len) {
   if (in < 0 || in > 0x10FFFF || (in >= 0xD800 && in <= 0xDFFF)) {
     gdv_fn_context_set_error_msg(
-        context, "Input is not a valid Unicode code point in the range 0 to 0x10FFFF");
+        context, "Input is not a valid Unicode code point.");
     *out_len = 0;
     return "";
   }

--- a/cpp/src/gandiva/precompiled/string_ops.cc
+++ b/cpp/src/gandiva/precompiled/string_ops.cc
@@ -1387,12 +1387,27 @@ gdv_int32 ascii_utf8(const char* data, gdv_int32 data_len) {
   return static_cast<gdv_int32>(static_cast<signed char>(data[0]));
 }
 
-// Returns the ASCII character having the binary equivalent to A.
-// If A is larger than 256 the result is equivalent to chr(A % 256).
+// Returns the UTF-8 encoding of the Unicode code point A.
+// Raises an error if A is not a valid code point, i.e. it is negative, greater
+// than 0x10FFFF, or falls within the UTF-16 surrogate range 0xD800-0xDFFF.
 FORCE_INLINE
-const char* chr_int32(gdv_int64 context, gdv_int32 in, gdv_int32* out_len) {
-  in = in % 256;
-  *out_len = 1;
+const char* chr_int64(gdv_int64 context, gdv_int64 in, gdv_int32* out_len) {
+  if (in < 0 || in > 0x10FFFF || (in >= 0xD800 && in <= 0xDFFF)) {
+    gdv_fn_context_set_error_msg(
+        context, "Input is not a valid Unicode code point in the range 0 to 0x10FFFF");
+    *out_len = 0;
+    return "";
+  }
+
+  if (in <= 0x7F) {
+    *out_len = 1;
+  } else if (in <= 0x7FF) {
+    *out_len = 2;
+  } else if (in <= 0xFFFF) {
+    *out_len = 3;
+  } else {
+    *out_len = 4;
+  }
 
   char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
   if (ret == nullptr) {
@@ -1400,25 +1415,34 @@ const char* chr_int32(gdv_int64 context, gdv_int32 in, gdv_int32* out_len) {
     *out_len = 0;
     return "";
   }
-  ret[0] = char(in);
+
+  switch (*out_len) {
+    case 1:
+      ret[0] = static_cast<char>(in);
+      break;
+    case 2:
+      ret[0] = static_cast<char>(0xC0 | (in >> 6));
+      ret[1] = static_cast<char>(0x80 | (in & 0x3F));
+      break;
+    case 3:
+      ret[0] = static_cast<char>(0xE0 | (in >> 12));
+      ret[1] = static_cast<char>(0x80 | ((in >> 6) & 0x3F));
+      ret[2] = static_cast<char>(0x80 | (in & 0x3F));
+      break;
+    case 4:
+      ret[0] = static_cast<char>(0xF0 | (in >> 18));
+      ret[1] = static_cast<char>(0x80 | ((in >> 12) & 0x3F));
+      ret[2] = static_cast<char>(0x80 | ((in >> 6) & 0x3F));
+      ret[3] = static_cast<char>(0x80 | (in & 0x3F));
+      break;
+  }
   return ret;
 }
 
-// Returns the ASCII character having the binary equivalent to A.
-// If A is larger than 256 the result is equivalent to chr(A % 256).
+// Returns the UTF-8 encoding of the Unicode code point A. See chr_int64.
 FORCE_INLINE
-const char* chr_int64(gdv_int64 context, gdv_int64 in, gdv_int32* out_len) {
-  in = in % 256;
-  *out_len = 1;
-
-  char* ret = reinterpret_cast<char*>(gdv_fn_context_arena_malloc(context, *out_len));
-  if (ret == nullptr) {
-    gdv_fn_context_set_error_msg(context, "Could not allocate memory for output string");
-    *out_len = 0;
-    return "";
-  }
-  ret[0] = char(in);
-  return ret;
+const char* chr_int32(gdv_int64 context, gdv_int32 in, gdv_int32* out_len) {
+  return chr_int64(context, in, out_len);
 }
 
 FORCE_INLINE

--- a/cpp/src/gandiva/precompiled/string_ops_test.cc
+++ b/cpp/src/gandiva/precompiled/string_ops_test.cc
@@ -56,11 +56,12 @@ TEST(TestStringOps, TestAscii) {
 }
 
 TEST(TestStringOps, TestChrBigInt) {
-  // CHR
+  // CHR returns the UTF-8 encoding of the given Unicode code point.
   gandiva::ExecutionContext ctx;
   uint64_t ctx_ptr = reinterpret_cast<gdv_int64>(&ctx);
   int32_t out_len = 0;
 
+  // 1-byte ASCII code points.
   auto out = chr_int32(ctx_ptr, 88, &out_len);
   EXPECT_EQ(std::string(out, out_len), "X");
 
@@ -70,62 +71,88 @@ TEST(TestStringOps, TestChrBigInt) {
   out = chr_int32(ctx_ptr, 49, &out_len);
   EXPECT_EQ(std::string(out, out_len), "1");
 
-  out = chr_int64(ctx_ptr, 84, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "T");
-
-  out = chr_int32(ctx_ptr, 340, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "T");
-
-  out = chr_int64(ctx_ptr, 256, &out_len);
-  EXPECT_EQ(std::strcmp(out, "\0"), 0);
-
   out = chr_int32(ctx_ptr, 33, &out_len);
   EXPECT_EQ(std::string(out, out_len), "!");
 
-  out = chr_int64(ctx_ptr, 46, &out_len);
-  EXPECT_EQ(std::string(out, out_len), ".");
-
-  out = chr_int32(ctx_ptr, 63, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "?");
-
   out = chr_int64(ctx_ptr, 0, &out_len);
-  EXPECT_EQ(std::strcmp(out, "\0"), 0);
-
-  out = chr_int32(ctx_ptr, -158, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "b");
-
-  out = chr_int64(ctx_ptr, -5, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\xFB");
-
-  out = chr_int32(ctx_ptr, -340, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\xAC");
-
-  out = chr_int64(ctx_ptr, -66, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\xBE");
-
-  //€
-  out = chr_int32(ctx_ptr, 128, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\x80");
-
-  //œ
-  out = chr_int64(ctx_ptr, 156, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\x9C");
-
-  //ÿ
-  out = chr_int32(ctx_ptr, 255, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\xFF");
+  EXPECT_EQ(std::string(out, out_len), std::string("\0", 1));
 
   // BACKSPACE
   out = chr_int64(ctx_ptr, 8, &out_len);
   EXPECT_EQ(std::string(out, out_len), "\b");
 
-  // DEVICE CONTROL 3 (DC3)
-  out = chr_int32(ctx_ptr, 19, &out_len);
-  EXPECT_EQ(std::string(out, out_len), "\x13");
-
   // ESCAPE (ESC)
   out = chr_int64(ctx_ptr, 27, &out_len);
   EXPECT_EQ(std::string(out, out_len), "\x1B");
+
+  // Highest 1-byte code point (U+007F, DELETE).
+  out = chr_int32(ctx_ptr, 0x7F, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\x7F");
+
+  // 2-byte code points.
+  // Lowest 2-byte code point (U+0080).
+  out = chr_int32(ctx_ptr, 0x80, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xC2\x80");
+
+  // í (U+00ED)
+  out = chr_int32(ctx_ptr, 237, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xC3\xAD");
+
+  // Highest 2-byte code point (U+07FF).
+  out = chr_int64(ctx_ptr, 0x7FF, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xDF\xBF");
+
+  // 3-byte code points.
+  // Lowest 3-byte code point (U+0800).
+  out = chr_int32(ctx_ptr, 0x800, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xE0\xA0\x80");
+
+  // € (U+20AC)
+  out = chr_int32(ctx_ptr, 8364, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xE2\x82\xAC");
+
+  // 日 (U+65E5)
+  out = chr_int64(ctx_ptr, 26085, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xE6\x97\xA5");
+
+  // Highest 3-byte code point (U+FFFF).
+  out = chr_int32(ctx_ptr, 0xFFFF, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xEF\xBF\xBF");
+
+  // 4-byte code points.
+  // Lowest 4-byte code point (U+10000).
+  out = chr_int64(ctx_ptr, 0x10000, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xF0\x90\x80\x80");
+
+  // 😀 (U+1F600)
+  out = chr_int64(ctx_ptr, 0x1F600, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xF0\x9F\x98\x80");
+
+  // Highest valid code point (U+10FFFF).
+  out = chr_int64(ctx_ptr, 0x10FFFF, &out_len);
+  EXPECT_EQ(std::string(out, out_len), "\xF4\x8F\xBF\xBF");
+
+  EXPECT_FALSE(ctx.has_error());
+
+  // Invalid code points raise an error.
+  chr_int64(ctx_ptr, -1, &out_len);
+  EXPECT_EQ(out_len, 0);
+  EXPECT_TRUE(ctx.get_error().find("not a valid Unicode code point") != std::string::npos)
+      << ctx.get_error();
+  ctx.Reset();
+
+  chr_int64(ctx_ptr, 0x110000, &out_len);
+  EXPECT_EQ(out_len, 0);
+  EXPECT_TRUE(ctx.get_error().find("not a valid Unicode code point") != std::string::npos)
+      << ctx.get_error();
+  ctx.Reset();
+
+  // UTF-16 surrogate range is not a valid code point.
+  chr_int32(ctx_ptr, 0xD800, &out_len);
+  EXPECT_EQ(out_len, 0);
+  EXPECT_TRUE(ctx.get_error().find("not a valid Unicode code point") != std::string::npos)
+      << ctx.get_error();
+  ctx.Reset();
 }
 
 TEST(TestStringOps, TestBeginsEnds) {


### PR DESCRIPTION
# CHR Unicode Support — Change Summary

## Problem

`CHR(n)` only worked for ASCII (0–127). Values ≥ 128 emitted a single raw byte
(invalid UTF‑8), causing "Error during planning". Goal: emit the proper
multi‑byte **UTF‑8 encoding** of the Unicode code point, consistent with
PostgreSQL/Snowflake.

All changes are **modifications** (no new files), on the `chr` branch in both repos.

## Arrow (C++ / Gandiva)

| File | Change |
|------|--------|
| `cpp/src/gandiva/precompiled/string_ops.cc` | `chr_int64` rewritten to UTF‑8‑encode the code point (1–4 bytes) and error on invalid input (negative, > 0x10FFFF, surrogate range 0xD800–0xDFFF). `chr_int32` now delegates to it. |
| `cpp/src/gandiva/precompiled/string_ops_test.cc` | `TestChrBigInt` rewritten for UTF‑8 semantics: every byte‑length boundary (1/2/3/4‑byte, low+high), í/€/日/😀, and the three invalid‑input error cases. |
